### PR TITLE
Make .travis.yml consistent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ branches:
   only:
     - "master"
 
-cache: pip
-
 install:
   - pip install -r requirements.txt
   - pip install -r requirements-ci.txt
@@ -20,3 +18,8 @@ script:
   - coveralls
 after_success:
   - python deploy.py
+
+cache: pip
+
+notifications:
+  email: false


### PR DESCRIPTION
Reordered the location of `cache: pip` to be consistent with https://github.com/discord-python/bot/blob/master/.travis.yml on the bot, and disabled email notifications like the bot repo.

Cosistency is winsistency.