### PR TITLE
Declaring the encoding to be utf-8 is not necessary in Python3.

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 from os import environ
 
 from pysite.route_manager import RouteManager

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 def when_ready(server=None):
     """ server hook that only runs when the gunicorn master process loads """
 

--- a/pysite/__init__.py
+++ b/pysite/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import logging
 import sys
 from logging import Logger, StreamHandler

--- a/pysite/base_route.py
+++ b/pysite/base_route.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from collections import Iterable
 from typing import Any
 

--- a/pysite/constants.py
+++ b/pysite/constants.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 from enum import Enum, IntEnum
 from os import environ
 

--- a/pysite/decorators.py
+++ b/pysite/decorators.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import os
 from functools import wraps
 from json import JSONDecodeError

--- a/pysite/logs.py
+++ b/pysite/logs.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from logging.handlers import SocketHandler
 
 

--- a/pysite/mixins.py
+++ b/pysite/mixins.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from weakref import ref
 
 from flask import Blueprint

--- a/pysite/route_manager.py
+++ b/pysite/route_manager.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import importlib
 import inspect
 import logging

--- a/pysite/rst/__init__.py
+++ b/pysite/rst/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import re
 
 from docutils.core import publish_parts

--- a/pysite/rst/directives/__init__.py
+++ b/pysite/rst/directives/__init__.py
@@ -1,1 +1,0 @@
-# coding=utf-8

--- a/pysite/rst/roles.py
+++ b/pysite/rst/roles.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from docutils import nodes
 from docutils.parsers.rst.roles import set_classes
 from docutils.parsers.rst.states import Inliner

--- a/pysite/views/api/__init__.py
+++ b/pysite/views/api/__init__.py
@@ -1,1 +1,0 @@
-# coding=utf-8

--- a/pysite/views/api/bot/hiphopify.py
+++ b/pysite/views/api/bot/hiphopify.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import datetime
 import logging
 

--- a/pysite/views/api/bot/tags.py
+++ b/pysite/views/api/bot/tags.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 from flask import jsonify
 from schema import Optional, Schema
 

--- a/pysite/views/api/bot/user.py
+++ b/pysite/views/api/bot/user.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import logging
 
 from flask import jsonify, request

--- a/pysite/views/api/error_view.py
+++ b/pysite/views/api/error_view.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from flask import jsonify
 from werkzeug.exceptions import HTTPException
 

--- a/pysite/views/api/healthcheck.py
+++ b/pysite/views/api/healthcheck.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from flask import jsonify
 
 from pysite.base_route import APIView

--- a/pysite/views/api/index.py
+++ b/pysite/views/api/index.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from pysite.base_route import APIView
 from pysite.constants import ErrorCodes
 

--- a/pysite/views/error_handlers/http_4xx.py
+++ b/pysite/views/error_handlers/http_4xx.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from flask import request
 from werkzeug.exceptions import HTTPException
 

--- a/pysite/views/error_handlers/http_5xx.py
+++ b/pysite/views/error_handlers/http_5xx.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from flask import request
 from werkzeug.exceptions import HTTPException, InternalServerError
 

--- a/pysite/views/main/__init__.py
+++ b/pysite/views/main/__init__.py
@@ -1,1 +1,0 @@
-# coding=utf-8

--- a/pysite/views/main/abort.py
+++ b/pysite/views/main/abort.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from werkzeug.exceptions import InternalServerError
 
 from pysite.base_route import RouteView

--- a/pysite/views/main/about/__init__.py
+++ b/pysite/views/main/about/__init__.py
@@ -1,1 +1,0 @@
-# coding=utf-8

--- a/pysite/views/main/about/index.py
+++ b/pysite/views/main/about/index.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from pysite.base_route import RouteView
 
 

--- a/pysite/views/main/about/partners.py
+++ b/pysite/views/main/about/partners.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import json
 from logging import getLogger
 

--- a/pysite/views/main/about/rules.py
+++ b/pysite/views/main/about/rules.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from pysite.base_route import RouteView
 
 

--- a/pysite/views/main/error.py
+++ b/pysite/views/main/error.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from flask import abort
 
 from pysite.base_route import RouteView

--- a/pysite/views/main/index.py
+++ b/pysite/views/main/index.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from pysite.base_route import RouteView
 
 

--- a/pysite/views/main/info/__init__.py
+++ b/pysite/views/main/info/__init__.py
@@ -1,1 +1,0 @@
-# coding=utf-8

--- a/pysite/views/main/info/help.py
+++ b/pysite/views/main/info/help.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from pysite.base_route import RouteView
 
 

--- a/pysite/views/main/info/index.py
+++ b/pysite/views/main/info/index.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from pysite.base_route import RouteView
 
 

--- a/pysite/views/main/info/jams.py
+++ b/pysite/views/main/info/jams.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from pysite.base_route import RouteView
 
 

--- a/pysite/views/main/info/resources.py
+++ b/pysite/views/main/info/resources.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import json
 from logging import getLogger
 

--- a/pysite/views/main/redirects/github.py
+++ b/pysite/views/main/redirects/github.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from flask import redirect
 
 from pysite.base_route import RouteView

--- a/pysite/views/main/redirects/invite.py
+++ b/pysite/views/main/redirects/invite.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from flask import redirect
 
 from pysite.base_route import RouteView

--- a/pysite/views/main/redirects/stats.py
+++ b/pysite/views/main/redirects/stats.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from flask import redirect
 
 from pysite.base_route import RouteView

--- a/pysite/views/main/ws_test.py
+++ b/pysite/views/main/ws_test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import os
 
 from pysite.base_route import RouteView

--- a/pysite/views/main/ws_test_rst.py
+++ b/pysite/views/main/ws_test_rst.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import os
 
 from pysite.base_route import RouteView

--- a/pysite/views/staff/index.py
+++ b/pysite/views/staff/index.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from pprint import pformat
 
 from flask import current_app

--- a/pysite/views/tests/index.py
+++ b/pysite/views/tests/index.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 from flask import jsonify
 from schema import Schema
 

--- a/pysite/views/wiki/edit.py
+++ b/pysite/views/wiki/edit.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import datetime
 import difflib
 

--- a/pysite/views/wiki/history/compare.py
+++ b/pysite/views/wiki/history/compare.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import difflib
 
 from pygments import highlight

--- a/pysite/views/wiki/history/show.py
+++ b/pysite/views/wiki/history/show.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import datetime
 
 from werkzeug.exceptions import NotFound

--- a/pysite/views/wiki/index.py
+++ b/pysite/views/wiki/index.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from flask import url_for
 from werkzeug.utils import redirect
 

--- a/pysite/views/wiki/page.py
+++ b/pysite/views/wiki/page.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from flask import redirect, url_for
 from werkzeug.exceptions import NotFound
 

--- a/pysite/views/wiki/render.py
+++ b/pysite/views/wiki/render.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import re
 
 from docutils.utils import SystemMessage

--- a/pysite/views/wiki/source.py
+++ b/pysite/views/wiki/source.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from flask import redirect, url_for
 from pygments import highlight
 from pygments.formatters.html import HtmlFormatter

--- a/pysite/views/ws/echo.py
+++ b/pysite/views/ws/echo.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import logging
 
 from geventwebsocket.websocket import WebSocket

--- a/pysite/views/ws/rst.py
+++ b/pysite/views/ws/rst.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import logging
 
 from geventwebsocket.websocket import WebSocket

--- a/pysite/websockets.py
+++ b/pysite/websockets.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from flask import Blueprint
 from geventwebsocket.websocket import WebSocket
 


### PR DESCRIPTION
UTF-8 is the default encoding in Python3 - see [PEP3120](https://www.python.org/dev/peps/pep-3120/). Encoding declarations are only useful in py3 if you want to declare it to be something _other_ than utf-8.

This is basically a Python2 convention that someone has carried over. Since it doesn't actually do anything at all, it should be removed.