### PR TITLE
Minor adjustments to payment icon alignment and margins

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -138,3 +138,12 @@ img.navbar-logo {
 #wiki-nav uk-nav-divider {
     min-width: 7rem;
 }
+
+/* Resource page styling */
+div.payment-icon img {
+    height: 2em;
+}
+
+div.payment-icon {
+    margin-right: 1em;
+}

--- a/templates/main/info/resources.html
+++ b/templates/main/info/resources.html
@@ -28,15 +28,22 @@
                     a resource or not. You can also hover them for more information on the payment (or tap them on
                     mobile).
                 </p>
-                <p class="uk-text-center">
-                    <img src="{{ static_file("images/payment_icons/green.svg") }}" style="height: 2rem;" uk-tooltip="Free" />
-                    Free
-                    <img src="{{ static_file("images/payment_icons/yellow.svg") }}" style="height: 2rem;" uk-tooltip="Payment Optional" />
-                    Payment Optional
-                    <img src="{{ static_file("images/payment_icons/red.svg") }}" style="height: 2rem;" uk-tooltip="Paid" />
-                    Paid
-                </p>
+                <div class="uk-text-center uk-flex uk-flex-center">
+                    <div class="payment-icon">
+                        <img src="{{ static_file("images/payment_icons/green.svg") }}" uk-tooltip="Free" />
+                        <span>Free</span>
+                    </div>
 
+                    <div class="payment-icon">
+                        <img src="{{ static_file("images/payment_icons/yellow.svg") }}" uk-tooltip="Payment Optional" />
+                        <span>Payment optional</span>
+                    </div>
+
+                    <div class="payment-icon">
+                        <img src="{{ static_file("images/payment_icons/red.svg") }}" uk-tooltip="Paid" />
+                        <span>Paid</span>
+                    </div>
+                </div>
                 {% if categories is none %}
                     <div class="uk-alert-danger" uk-alert>
                         <p>


### PR DESCRIPTION
This changes this:

![image](https://user-images.githubusercontent.com/2098517/39361590-80c4117a-4a23-11e8-9666-8e0e8fa8c8c4.png)

To this:

![image](https://user-images.githubusercontent.com/2098517/39361599-90317f44-4a23-11e8-9666-69ef955a1e9f.png)

...by using `flexbox`, of course.