### PR TITLE
[Wiki] Prefer horizontal whitespace over vertical

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -249,7 +249,7 @@ textarea.fira-code {
 }
 
 #doc-view div {
-    width: calc(100% - 6rem);
+    width: calc(100% - 2rem);
 }
 
 @media (max-width: 639px) {

--- a/templates/wiki/base.html
+++ b/templates/wiki/base.html
@@ -188,11 +188,13 @@
                         </li>
                     </ul>
                 </div>
-                <a class="uk-flex-left uk-flex uk-flex-column uk-background-primary uk-hidden@s uk-hidden@m uk-hidden@l uk-hidden@xl" id="wiki-sidebar-button">
-                    <div class="uk-flex-center"><i class="uk-icon fa-fw far fa-bars"></i></div>
-                </a>
-                <div class="uk-section uk-flex uk-flex-column" style="flex-grow: 1; margin: 0 1rem 1rem; width: calc(100% - 6rem)">
-                    {% block content %}{% endblock %}
+                    <div style="width: 100%;">
+                    <a class="uk-flex-left uk-flex uk-flex-column uk-background-primary uk-hidden@s uk-hidden@m uk-hidden@l uk-hidden@xl" id="wiki-sidebar-button">
+                        <div class="uk-flex-center"><i class="uk-icon fa-fw far fa-bars"></i></div>
+                    </a>
+                    <div class="uk-section uk-flex uk-flex-column" style="flex-grow: 1; margin: 0 1rem 1rem;">
+                        {% block content %}{% endblock %}
+                    </div>
                 </div>
             </div>
         </div>

--- a/templates/wiki/base.html
+++ b/templates/wiki/base.html
@@ -188,7 +188,7 @@
                         </li>
                     </ul>
                 </div>
-                    <div style="width: 100%;">
+                <div style="width: 100%;">
                     <a class="uk-flex-left uk-flex uk-flex-column uk-background-primary uk-hidden@s uk-hidden@m uk-hidden@l uk-hidden@xl" id="wiki-sidebar-button">
                         <div class="uk-flex-center"><i class="uk-icon fa-fw far fa-bars"></i></div>
                     </a>

--- a/templates/wiki/base.html
+++ b/templates/wiki/base.html
@@ -188,11 +188,13 @@
                         </li>
                     </ul>
                 </div>
-                <a class="uk-flex-left uk-flex uk-flex-column uk-background-primary uk-hidden@s uk-hidden@m uk-hidden@l uk-hidden@xl" id="wiki-sidebar-button">
-                    <div class="uk-flex-center"><i class="uk-icon fa-fw far fa-bars"></i></div>
-                </a>
-                <div class="uk-section uk-flex uk-flex-column" id="doc-view" style="flex-grow: 1; margin: 0 1rem 1rem; width: calc(100% - 6rem)">
-                    {% block content %}{% endblock %}
+                <div style="width: 100%;">
+                    <a class="uk-flex-left uk-flex uk-flex-column uk-background-primary uk-hidden@s uk-hidden@m uk-hidden@l uk-hidden@xl" id="wiki-sidebar-button">
+                        <div class="uk-flex-center"><i class="uk-icon fa-fw far fa-bars"></i></div>
+                    </a>
+                    <div class="uk-section uk-flex uk-flex-column" id="doc-view" style="flex-grow: 1; margin: 0 1rem 1rem;">
+                        {% block content %}{% endblock %}
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This should fix the issue with the long vertical bar of whitespace under the menu
toggle button on mobile, whilst also not breaking centering of content.

Before this commit, pages looked like this on mobile:

![wiki pythondiscord com_wiki_home](https://user-images.githubusercontent.com/36747857/40879181-ec00869c-66a4-11e8-94e0-f4d52ff736f4.png)

This was quite inefficient use of space, especially on pages with more content. This commit aims to replace that long vertical whitespace on the left with a horizontal one above the page content, so the page looks like this:

![wiki pythondiscord com_wiki_home 1](https://user-images.githubusercontent.com/36747857/40879190-07fc9e62-66a5-11e8-8ebc-216841e75e62.png)
