### PR TITLE
Adding 'Thonny', a Python IDE aimed at beginners, to our resources list

### DIFF
--- a/static/resources.json
+++ b/static/resources.json
@@ -528,6 +528,23 @@
             "url": "https://www.jetbrains.com/pycharm/"
           }
         ]
+      },
+      "Thonny": {
+        "description": "A Python IDE specifially aimed at learning programming. Has a lot of helpful features to help you understand your code.",
+        "payment": "free",
+        "payment_description": null,
+        "urls": [
+          {
+            "icon": "regular/link",
+            "title": "Website",
+            "url": "https://thonny.org/"
+          },
+          {
+            "icon": "branding/github",
+            "title": "GitHub",
+            "url": "https://github.com/thonny/thonny/"
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
Adding Thonny has been discussed a couple of times in chat and I know some people were in favor of it. Personally, I think it's a great tool as it allows for easy variable introspection and function calls. 

I think it's also nice to have a beginner/learning IDE on our list along side our beginner/learning editor of choice, Mu.

The changes:

![Thonny in IDE Resources list](https://user-images.githubusercontent.com/33516116/50631566-0e626400-0f45-11e9-9eb2-bf687b70ecb5.png "Adding Thonny to IDEs")
