### PR TITLE
Add Test & Code to podcasts

### DIFF
--- a/static/resources.json
+++ b/static/resources.json
@@ -498,6 +498,18 @@
             "url": "https://www.podcastinit.com/"
           }
         ]
+      },
+      "Test & Code": {
+        "description": "This weekly show covers a wide array of topics including software development, testing, Python programming, and many related topics.",
+        "payment": "free",
+        "payment_description": null,
+        "urls": [
+          {
+            "icon": "regular/link",
+            "title": "Website",
+            "url": "https://testandcode.com/"
+          }
+        ]
       }
     }
   },


### PR DESCRIPTION
[Test & Code](https://testandcode.com/) is a weekly podcast hosted by Brian Okken, who also hosts [Python Bytes](https://pythonbytes.fm/) with (Rockstar) Michael Kennedy.

From their description:

>The show covers a wide array of topics including software development, testing, Python programming, and many related topics. 
When we get into the implementation specifics, that's usually Python, such as Python packaging, tox, pytest, and unittest. However, well over half of the topics are language agnostic, such as data science, DevOps, TDD, public speaking, mentoring, feature testing, NoSQL databases, end to end testing, automation, continuous integration, development methods, Selenium, the testing pyramid, and DevOps.