### PR TITLE
Line Ending Fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Declare files that will always have LF line endings on checkout
+# This prevents git on Windows from automatically inserting CRLF line endings
+* text=auto eol=lf

--- a/docker/app/scripts/migrate_and_serve.sh
+++ b/docker/app/scripts/migrate_and_serve.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/bin/sh
+set -eu
 
 ### NOTE
 # This file is intended to be used by local setups.


### PR DESCRIPTION
Added .gitattributes to prevent Windows users from accidentally cloning the repo and getting incorrect line endings

Also adjusting the shebang for the migrate_and_serve.sh to prevent another Windows related bug