### PR TITLE
Monkeypatch in new HEADER_ID_PREFIX.

### DIFF
--- a/pydis_site/__init__.py
+++ b/pydis_site/__init__.py
@@ -1,0 +1,4 @@
+from wiki.plugins.macros.mdx import toc
+
+# Remove the toc header prefix. There's no option for this, so we gotta monkey patch it.
+toc.HEADER_ID_PREFIX = ''


### PR DESCRIPTION
Currently, all toc-links will have a wiki-toc prefix. This commit removes this prefix, so that we can header link with just something like `#environment` instead of `#wiki-toc-environment`.

There's no option for this in the `django-wiki`, so this monkeypatch is the best solution I could find. I'm not super happy with it, though, so if anyone has a better solution, do let me know.

Closes #267.
