### PR TITLE
Add link to Contributing landing page to our website's navbar

### DIFF
--- a/pydis_site/templates/base/navbar.html
+++ b/pydis_site/templates/base/navbar.html
@@ -67,6 +67,9 @@
           <a class="navbar-item" href="{% url 'wiki:get' path="tools/" %}">
             Tools
           </a>
+          <a class="navbar-item" href="{% url 'wiki:get' path="contributing/" %}">
+            Contributing
+          </a>
           <a class="navbar-item" href="{% url 'wiki:get' path="frequently-asked-questions/" %}">
             FAQ
           </a>


### PR DESCRIPTION
This adds a link to the contributing page to the navbar on our website.