### PR TITLE
Add jump_url to the reminder model for bot#466

### DIFF
--- a/pydis_site/apps/api/models/bot/reminder.py
+++ b/pydis_site/apps/api/models/bot/reminder.py
@@ -35,7 +35,7 @@ class Reminder(ModelReprMixin, models.Model):
     jump_url = models.CharFiels(
         help_text=("The jump url of the message "
                    "that created the reminder"
-                  )
+        )
     )
     content = models.CharField(
         max_length=1500,

--- a/pydis_site/apps/api/models/bot/reminder.py
+++ b/pydis_site/apps/api/models/bot/reminder.py
@@ -32,6 +32,11 @@ class Reminder(ModelReprMixin, models.Model):
             ),
         )
     )
+    jump_url = models.CharFiels(
+        help_text=("The jump url of the message "
+                   "that created the reminder"
+                  )
+    )
     content = models.CharField(
         max_length=1500,
         help_text="The content that the user wants to be reminded of."

--- a/pydis_site/apps/api/models/bot/reminder.py
+++ b/pydis_site/apps/api/models/bot/reminder.py
@@ -33,8 +33,9 @@ class Reminder(ModelReprMixin, models.Model):
         )
     )
     jump_url = models.CharFiels(
-        help_text=("The jump url of the message "
-                   "that created the reminder"
+        help_text=(
+            "The jump url of the message "
+            "that created the reminder"
         )
     )
     content = models.CharField(

--- a/pydis_site/apps/api/serializers.py
+++ b/pydis_site/apps/api/serializers.py
@@ -190,7 +190,7 @@ class ReminderSerializer(ModelSerializer):
         """Metadata defined for the Django REST Framework."""
 
         model = Reminder
-        fields = ('active', 'author', 'channel_id', 'content', 'expiration', 'id')
+        fields = ('active', 'author', 'channel_id', 'jump_url', 'content', 'expiration', 'id')
 
 
 class RoleSerializer(ModelSerializer):

--- a/pydis_site/apps/api/tests/test_models.py
+++ b/pydis_site/apps/api/tests/test_models.py
@@ -94,6 +94,7 @@ class StringDunderMethodTests(SimpleTestCase):
                     discriminator=5, avatar_hash=None
                 ),
                 channel_id=555,
+                jump_url="billy's awsome message",
                 content="oh no",
                 expiration=dt(5018, 11, 20, 15, 52, tzinfo=timezone.utc)
             )


### PR DESCRIPTION
Hi, this PR add a jump_url field to the reminder model. 

This PR should be merged at the same time than python-discord/bot#466