### PR TITLE
Add bulma content class to home page content for proper formatting.

### DIFF
--- a/pydis_site/templates/home/index.html
+++ b/pydis_site/templates/home/index.html
@@ -16,7 +16,7 @@
       <h1 class="is-size-1">Who are we?</h1>
       <br>
       <div class="columns is-desktop">
-        <div class="column is-half-desktop">
+        <div class="column is-half-desktop content">
           <p>
             We're a large community focused around the Python programming language.
             We believe anyone can learn to code, and are very dedicated to helping


### PR DESCRIPTION
Bulma does a lot of css normalisation in order to keep cross-browser consistency. One of these by default is to remove any padding and margins from the paragraph tag (`<p></p>`). 

It does have though a `content` class that's suitable for plain html text content which applies it's own consistent test styling, including an appropriate paragraph padding, so I've added this into the element where the front page text is.  

Before:
![image](https://user-images.githubusercontent.com/29337040/67160774-83e5d680-f397-11e9-99f1-3ffbfb34ae9d.png)


After:
![image](https://user-images.githubusercontent.com/29337040/67160768-74668d80-f397-11e9-83b9-80b765069920.png)
