### PR TITLE
Set SECRET_KEY to a constant in DEBUG mode

### DIFF
--- a/pydis_site/settings.py
+++ b/pydis_site/settings.py
@@ -48,7 +48,7 @@ if DEBUG:
             'staff.web'
         ]
     )
-    SECRET_KEY = secrets.token_urlsafe(32)
+    SECRET_KEY = "yellow polkadot bikini"  # noqa: S105
 
 elif 'CI' in os.environ:
     ALLOWED_HOSTS = ['*']


### PR DESCRIPTION
The SECRET_KEY in debug mode was auto-generated each time the config file was loaded. This had the unwanted side-effect of requiring testers to login again after every change they made, since the auto-reloading process would also create a new SECRET_KEY.

This commit resolves that by turning it into a constant. Since having a constant "secret" results in the linting error `S105`, I have added a specific `noqa` ignore for that to avoid having to add an otherwise useless environment variable. 