### PR TITLE
Add pipenv run start command

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -43,6 +43,7 @@ unittest-xml-reporting = "~=2.5.1"
 python_version = "3.7"
 
 [scripts]
+start = "python manage.py run"
 makemigrations = "python manage.py makemigrations"
 django_shell = "python manage.py shell"
 test = "coverage run manage.py test"

--- a/Pipfile
+++ b/Pipfile
@@ -43,7 +43,7 @@ unittest-xml-reporting = "~=2.5.1"
 python_version = "3.7"
 
 [scripts]
-start = "python manage.py run"
+start = "python manage.py run --debug"
 makemigrations = "python manage.py makemigrations"
 django_shell = "python manage.py shell"
 test = "coverage run manage.py test"


### PR DESCRIPTION
Hi, 
This PR just add a new `pipenv run start` command that would be _very_ useful to people that run the site without docker. 