### PR TITLE
Correct the Discord TOS link in rules API endpoint.

### DIFF
--- a/pydis_site/apps/api/views.py
+++ b/pydis_site/apps/api/views.py
@@ -110,7 +110,7 @@ class RulesView(APIView):
         )
         discord_tos = self._format_link(
             'Terms Of Service',
-            'https://discordapp.com/guidelines',
+            'https://discordapp.com/terms',
             link_format
         )
         pydis_coc = self._format_link(


### PR DESCRIPTION
In the rules bot command, the link to the Discord TOS for rule 1 was directing to the guidelines page instead. This corrects that.