### PR TITLE
Unbleach Wiki

### DIFF
--- a/pydis_site/settings.py
+++ b/pydis_site/settings.py
@@ -360,25 +360,7 @@ WIKI_MESSAGE_TAG_CSS_CLASS = {
     messages.WARNING: "is-warning",
 }
 
-WIKI_MARKDOWN_HTML_STYLES = [
-    'max-width',
-    'min-width',
-    'margin',
-    'padding',
-    'width',
-    'height',
-]
-
-WIKI_MARKDOWN_HTML_ATTRIBUTES = {
-    'img': ['class', 'id', 'src', 'alt', 'width', 'height'],
-    'section': ['class', 'id'],
-    'article': ['class', 'id'],
-    'iframe': ['width', 'height', 'src', 'frameborder', 'allow', 'allowfullscreen'],
-}
-
-WIKI_MARKDOWN_HTML_WHITELIST = [
-    'article', 'section', 'button', 'iframe'
-]
+WIKI_MARKDOWN_SANITIZE_HTML = False
 
 
 # Wiki permissions


### PR DESCRIPTION
Disables the sanitisation of HTML in wiki articles.

Considered unnecessary at this point due to articles being only created by mods+, rather than public members.

As there's no sanitisation, the whitelisting of HTML tags and attributes are also removed as they're no longer doing anything.

For easy reference to the relevant setting I'm setting:
https://django-wiki.readthedocs.io/en/master/settings.html#wiki.conf.settings.MARKDOWN_SANITIZE_HTML