### PR TITLE
Update resources reference in head navbar.

### DIFF
--- a/pydis_site/templates/base/navbar.html
+++ b/pydis_site/templates/base/navbar.html
@@ -63,9 +63,9 @@
         </a>
         <div class="navbar-dropdown">
           <a class="navbar-item" href="{% url 'wiki:get' path="resources/" %}">
-            Learning Resources
+            Resources
           </a>
-          <a class="navbar-item" href="{% url 'wiki:get' path="tools/" %}">
+          <a class="navbar-item" href="{% url 'wiki:get' path="resources/tools/" %}">
             Tools
           </a>
           <a class="navbar-item" href="{% url 'wiki:get' path="contributing/" %}">


### PR DESCRIPTION
Due to the tweak in the wiki page structure, the Tools page is now under resources, and Learning Resources is now just Resources.