### PR TITLE
Fix broken link to Game Jam 2020 banner

### DIFF
--- a/pydis_site/templates/home/index.html
+++ b/pydis_site/templates/home/index.html
@@ -40,7 +40,7 @@
         {# Right column container #}
         <div class="column is-half-desktop">
           <a href="https://pythondiscord.com/pages/events/game-jam-2020/">
-            <img src="https://raw.githubusercontent.com/python-discord/branding/master/logos/logo_discord_banner/game%20jam%202020/game%20jam%202020%20-%20website%20banner.png">
+            <img src="https://raw.githubusercontent.com/python-discord/branding/master/events/game%20jam%202020/game%20jam%202020%20-%20website%20banner.png">
           </a>
         </div>
       </div>


### PR DESCRIPTION
After https://github.com/python-discord/branding/pull/46, the location of the Game Jame 2020 asset has changed, breaking the link on the frontpage of `pythondiscord.com`.

This PR fixes the link:

![image](https://user-images.githubusercontent.com/44734341/78272617-0ad5d800-750e-11ea-927c-f108ba31455a.png)
