### PR TITLE
News IDs storage in bot settings

### DIFF
--- a/pydis_site/apps/api/migrations/0051_create_news_setting.py
+++ b/pydis_site/apps/api/migrations/0051_create_news_setting.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+def up(apps, schema_editor):
+    BotSetting = apps.get_model('api', 'BotSetting')
+    setting = BotSetting(
+        name='news',
+        data={}
+    ).save()
+
+
+def down(apps, schema_editor):
+    BotSetting = apps.get_model('api', 'BotSetting')
+    BotSetting.get(name='news').delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0050_remove_infractions_active_default_value'),
+    ]
+
+    operations = [
+        migrations.RunPython(up, down)
+    ]
+    

--- a/pydis_site/apps/api/migrations/0051_create_news_setting.py
+++ b/pydis_site/apps/api/migrations/0051_create_news_setting.py
@@ -11,7 +11,7 @@ def up(apps, schema_editor):
 
 def down(apps, schema_editor):
     BotSetting = apps.get_model('api', 'BotSetting')
-    BotSetting.get(name='news').delete()
+    BotSetting.objects.get(name='news').delete()
 
 
 class Migration(migrations.Migration):

--- a/pydis_site/apps/api/migrations/0051_create_news_setting.py
+++ b/pydis_site/apps/api/migrations/0051_create_news_setting.py
@@ -23,4 +23,3 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunPython(up, down)
     ]
-    

--- a/pydis_site/apps/api/models/bot/bot_setting.py
+++ b/pydis_site/apps/api/models/bot/bot_setting.py
@@ -9,6 +9,7 @@ def validate_bot_setting_name(name: str) -> None:
     """Raises a ValidationError if the given name is not a known setting."""
     known_settings = (
         'defcon',
+        'news',
     )
 
     if name not in known_settings:


### PR DESCRIPTION
Added `news` to allowed setting names, made migration for it. Part of Python bot upcoming Python News feature.