### PR TITLE
Update Game Jam from upcoming to most recent

### DIFF
--- a/pydis_site/templates/base/navbar.html
+++ b/pydis_site/templates/base/navbar.html
@@ -88,7 +88,7 @@
             <strong>Events</strong>
           </div>
           <a class="navbar-item" href="{% url 'wiki:get' path="events/game-jam-2020/" %}">
-            Upcoming: Game Jam 2020
+            Most Recent: Game Jam 2020
           </a>
           <a class="navbar-item" href="{% url 'wiki:get' path="events/" %}">
             All events


### PR DESCRIPTION
Updated the `More` drop-down menu in the nav bar to say `Most Recent: Game Jam 2020` instead of `Upcoming: Game Jam 2020` since the Game Jam is now over.