### PR TITLE
Allow direct fetching of reminders by id

### DIFF
--- a/pydis_site/apps/api/tests/test_reminders.py
+++ b/pydis_site/apps/api/tests/test_reminders.py
@@ -163,6 +163,34 @@ class ReminderListTests(APISubdomainTestCase):
         self.assertEqual(response.json(), [self.rem_dict_one])
 
 
+class ReminderRetrieveTests(APISubdomainTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.author = User.objects.create(
+            id=6789,
+            name='Reminder author',
+            discriminator=6789,
+        )
+
+        cls.reminder = Reminder.objects.create(
+            author=cls.author,
+            content="Reminder content",
+            expiration=datetime.utcnow().isoformat(),
+            jump_url="http://example.com/",
+            channel_id=123
+        )
+
+    def test_retrieve_unknown_returns_404(self):
+        url = reverse('bot:reminder-detail', args=("not_an_id",), host='api')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_retrieve_known_returns_200(self):
+        url = reverse('bot:reminder-detail', args=(self.reminder.id,), host='api')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
 class ReminderUpdateTests(APISubdomainTestCase):
     @classmethod
     def setUpTestData(cls):

--- a/pydis_site/apps/api/viewsets/bot/reminder.py
+++ b/pydis_site/apps/api/viewsets/bot/reminder.py
@@ -4,6 +4,7 @@ from rest_framework.mixins import (
     CreateModelMixin,
     DestroyModelMixin,
     ListModelMixin,
+    RetrieveModelMixin,
     UpdateModelMixin
 )
 from rest_framework.viewsets import GenericViewSet
@@ -13,7 +14,12 @@ from pydis_site.apps.api.serializers import ReminderSerializer
 
 
 class ReminderViewSet(
-    CreateModelMixin, ListModelMixin, DestroyModelMixin, UpdateModelMixin, GenericViewSet
+    CreateModelMixin,
+    RetrieveModelMixin,
+    ListModelMixin,
+    DestroyModelMixin,
+    UpdateModelMixin,
+    GenericViewSet,
 ):
     """
     View providing CRUD access to reminders.

--- a/pydis_site/apps/api/viewsets/bot/reminder.py
+++ b/pydis_site/apps/api/viewsets/bot/reminder.py
@@ -50,6 +50,30 @@ class ReminderViewSet(
     #### Status codes
     - 200: returned on success
 
+    ### GET /bot/reminders/<id:int>
+    Fetches the reminder with the given id.
+
+    #### Response format
+    >>>
+    ... {
+    ...     'active': True,
+    ...     'author': 1020103901030,
+    ...     'mentions': [
+    ...         336843820513755157,
+    ...         165023948638126080,
+    ...         267628507062992896
+    ...     ],
+    ...     'content': "Make dinner",
+    ...     'expiration': '5018-11-20T15:52:00Z',
+    ...     'id': 11,
+    ...     'channel_id': 634547009956872193,
+    ...     'jump_url': "https://discord.com/channels/<guild_id>/<channel_id>/<message_id>"
+    ... }
+
+    #### Status codes
+    - 200: returned on success
+    - 404: returned when the reminder doesn't exist
+
     ### POST /bot/reminders
     Create a new reminder.
 


### PR DESCRIPTION
Opens up the `bot/reminders/id` path for GET fetching of reminders by id