### PR TITLE
Reduce Discord OAuth2 scopes

### DIFF
--- a/pydis_site/settings.py
+++ b/pydis_site/settings.py
@@ -401,3 +401,10 @@ ACCOUNT_USERNAME_VALIDATORS = "pydis_site.VALIDATORS"
 
 LOGIN_REDIRECT_URL = "home"
 SOCIALACCOUNT_ADAPTER = "pydis_site.utils.account.SocialAccountAdapter"
+SOCIALACCOUNT_PROVIDERS = {
+    'discord': {
+        'SCOPE': [
+            'identify',
+        ],
+    }
+}

--- a/pydis_site/settings.py
+++ b/pydis_site/settings.py
@@ -402,9 +402,10 @@ ACCOUNT_USERNAME_VALIDATORS = "pydis_site.VALIDATORS"
 LOGIN_REDIRECT_URL = "home"
 SOCIALACCOUNT_ADAPTER = "pydis_site.utils.account.SocialAccountAdapter"
 SOCIALACCOUNT_PROVIDERS = {
-    'discord': {
-        'SCOPE': [
-            'identify',
+    "discord": {
+        "SCOPE": [
+            "identify",
         ],
+        "AUTH_PARAMS": {"prompt": "none"}
     }
 }


### PR DESCRIPTION
Closes #341 

By default, AllAuth requests both identify + email from Discord on an attempted login.

We don't have any use for this email and so we discard it immediately, but there is no reason why we need to request this scope at all.

This PR will change the Discord authenticate screen to only state that it is requesting the basic user details of a user.

<img width="453" alt="Screenshot 2020-10-02 at 23 49 17" src="https://user-images.githubusercontent.com/20439493/94975530-e46b1680-0509-11eb-8a21-740a63ded4da.png">

Additionally it passes the `prompt=none` parameter to the authorise URL. This means that if the user has previously authenticated they will not be asked to click confirm and will instead be redirected directly to the application, making the process much more seamless. Users can de-authenticate with us through the "Authorized Apps" section in the Discord client.