### PR TITLE
Allow requesting API data from internal DNS

### DIFF
--- a/pydis_site/settings.py
+++ b/pydis_site/settings.py
@@ -80,6 +80,7 @@ else:
             'api.pydis.com',
             'admin.pydis.com',
             'staff.pydis.com',
+            'api.site',
         ]
     )
     SECRET_KEY = env('SECRET_KEY')


### PR DESCRIPTION
Currently, we're experiencing some issues requesting API data via the public domain, likely caused by some Cloudflare weirdness. 

This change puts the internal domain `api.site`, referenceable through the internal Docker DNS only, in the whitelist of ALLOWED_HOSTS.

This should be merged before making further changes, so we can confirm the internal domain works as expected after a deployment and **before** we move change the bot to use it. 