### PR TITLE
Add activity blocks to Metricity data endpoint

### DIFF
--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -16,15 +16,18 @@ INSERT INTO users VALUES (
 CREATE TABLE messages (
     id varchar,
     author_id varchar references users(id),
-    primary key(id)
+    primary key(id),
+    is_deleted boolean
 );
 
 INSERT INTO messages VALUES(
     0,
-    0
+    0,
+    false
 );
 
 INSERT INTO messages VALUES(
     1,
-    0
+    0,
+    false
 );

--- a/pydis_site/apps/api/models/bot/metricity.py
+++ b/pydis_site/apps/api/models/bot/metricity.py
@@ -54,11 +54,7 @@ class Metricity:
               COUNT(*)
              FROM (
                SELECT
-                 to_timestamp(
-                    floor((extract('epoch' from created_at) / %d ))
-                    * %d
-                 )
-                 AT TIME ZONE 'UTC' AS interval
+                 (floor((extract('epoch' from created_at) / %d )) * %d) AS interval
                FROM messages
                WHERE
                  author_id='%s'

--- a/pydis_site/apps/api/models/bot/metricity.py
+++ b/pydis_site/apps/api/models/bot/metricity.py
@@ -49,12 +49,15 @@ class Metricity:
     def total_message_blocks(self, user_id: str) -> int:
         """Query number of 10 minute blocks the user has been active during."""
         self.cursor.execute(
-            """
+            f"""
             SELECT
               COUNT(*)
              FROM (
                SELECT
-                 to_timestamp(floor((extract('epoch' from created_at) / 600 )) * 600)
+                 to_timestamp(
+                    floor((extract('epoch' from created_at) / {BLOCK_INTERVAL} ))
+                    * {BLOCK_INTERVAL}
+                 )
                  AT TIME ZONE 'UTC' AS interval
                FROM messages
                WHERE

--- a/pydis_site/apps/api/models/bot/metricity.py
+++ b/pydis_site/apps/api/models/bot/metricity.py
@@ -55,15 +55,15 @@ class Metricity:
         self.cursor.execute(
             """
             SELECT
-              COUNT(*)
-             FROM (
-               SELECT
-                 (floor((extract('epoch' from created_at) / %d )) * %d) AS interval
-               FROM messages
-               WHERE
-                 author_id='%s'
-                 AND NOT is_deleted
-               GROUP BY interval
+                COUNT(*)
+            FROM (
+                SELECT
+                    (floor((extract('epoch' from created_at) / %d )) * %d) AS interval
+                FROM messages
+                WHERE
+                    author_id='%s'
+                    AND NOT is_deleted
+                GROUP BY interval
             ) block_query;
             """,
             [BLOCK_INTERVAL, BLOCK_INTERVAL, user_id]

--- a/pydis_site/apps/api/models/bot/metricity.py
+++ b/pydis_site/apps/api/models/bot/metricity.py
@@ -57,7 +57,11 @@ class Metricity:
                  to_timestamp(floor((extract('epoch' from created_at) / 600 )) * 600)
                  AT TIME ZONE 'UTC' AS interval
                FROM messages
-               WHERE author_id='%s' AND NOT is_deleted GROUP BY interval) block_query;
+               WHERE
+                 author_id='%s'
+                 AND NOT is_deleted
+               GROUP BY interval
+            ) block_query;
             """,
             [user_id]
         )

--- a/pydis_site/apps/api/models/bot/metricity.py
+++ b/pydis_site/apps/api/models/bot/metricity.py
@@ -55,8 +55,8 @@ class Metricity:
              FROM (
                SELECT
                  to_timestamp(
-                    floor((extract('epoch' from created_at) / {BLOCK_INTERVAL} ))
-                    * {BLOCK_INTERVAL}
+                    floor((extract('epoch' from created_at) / %d ))
+                    * %d
                  )
                  AT TIME ZONE 'UTC' AS interval
                FROM messages
@@ -66,7 +66,7 @@ class Metricity:
                GROUP BY interval
             ) block_query;
             """,
-            [user_id]
+            [BLOCK_INTERVAL, BLOCK_INTERVAL, user_id]
         )
         values = self.cursor.fetchone()
 

--- a/pydis_site/apps/api/models/bot/metricity.py
+++ b/pydis_site/apps/api/models/bot/metricity.py
@@ -47,7 +47,11 @@ class Metricity:
         return values[0]
 
     def total_message_blocks(self, user_id: str) -> int:
-        """Query number of 10 minute blocks the user has been active during."""
+        """
+        Query number of 10 minute blocks during which the user has been active.
+
+        This metric prevents users from spamming to achieve the message total threshold.
+        """
         self.cursor.execute(
             """
             SELECT

--- a/pydis_site/apps/api/models/bot/metricity.py
+++ b/pydis_site/apps/api/models/bot/metricity.py
@@ -49,7 +49,7 @@ class Metricity:
     def total_message_blocks(self, user_id: str) -> int:
         """Query number of 10 minute blocks the user has been active during."""
         self.cursor.execute(
-            f"""
+            """
             SELECT
               COUNT(*)
              FROM (

--- a/pydis_site/apps/api/viewsets/bot/user.py
+++ b/pydis_site/apps/api/viewsets/bot/user.py
@@ -110,7 +110,9 @@ class UserViewSet(ModelViewSet):
     #### Response format
     >>> {
     ...    "verified_at": "2020-10-06T21:54:23.540766",
-    ...    "total_messages": 2
+    ...    "total_messages": 2,
+    ...    "voice_banned": False,
+    ...    "activity_blocks": 1
     ...}
 
     #### Status codes
@@ -255,6 +257,7 @@ class UserViewSet(ModelViewSet):
                 data = metricity.user(user.id)
                 data["total_messages"] = metricity.total_messages(user.id)
                 data["voice_banned"] = voice_banned
+                data["activity_blocks"] = metricity.total_message_blocks(user.id)
                 return Response(data, status=status.HTTP_200_OK)
             except NotFound:
                 return Response(dict(detail="User not found in metricity"),


### PR DESCRIPTION
Voice gate has been a success (in general)! :tada:

One downside we have observed is users spamming in order to meet the 50 messages threshold, this is dissatisfactory and will not be tolerated!

This PR introduces a new response in the metricity data endpoint to show how many 10 minute intervals the requested user has been active in. This means how many blocks of 10 minutes has the user sent at least one message in.

A threshold for this has not been decided on for this yet, but this will allow us to mandate that the user gets their messages over a period of time.

If we wanted we could use this instead of a message constraint and say that the user must sent at least one (or any number of) messages per 10 minutes for 6 ten minute blocks.