### PR TITLE
Fix typo in timeline for DYEP and PyDis merge item

### DIFF
--- a/pydis_site/templates/home/timeline.html
+++ b/pydis_site/templates/home/timeline.html
@@ -125,7 +125,7 @@
             </div>
 
             <div class="cd-timeline__content text-component">
-                <h2>Do You Even Python and PyDis merger</h2>
+                <h2>Do You Even Python and PyDis merged</h2>
                 <p class="color-contrast-medium">At this point in time, there are only two serious Python communities on
                     Discord - Ours, and one called Do You Even Python. We approach the owners of DYEP with a bold
                     proposal - let's shut down their community, replace it with links to ours, and in return we will let


### PR DESCRIPTION
`merger` -> `merged`

Previously it was "Do You Even Python and PyDis merger", in the [timeline Google Doc](https://docs.google.com/document/d/1DWyqg63hg9hOcOF2qU83I6OQz-zjzxs8_1qr4L-9SXw/edit) it's "merge", but looking at the other items, "merged" seems better, so it's changed to that.

* Found this error while reading through the timeline, and I thought the description didn't mention anyone in particular that merged the two servers (because "merger"), so I guess that was a typo.
* I thought that this is a super minor change so I just committed online from GitHub directly, without setting up development environment or running pre-commit
* I guess if this doesn't sound good it could also be "merges"