### PR TITLE
Set max-requests-jitter parameter to gunicorn

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -163,7 +163,10 @@ class SiteManager:
             "-b", "0.0.0.0:8000",
             "pydis_site.wsgi:application",
             "--threads", "8",
-            "-w", "4"
+            "-w", "4",
+            "--max-requests-jitter", "1000",
+            "--statsd_host", "graphite.default.svc.cluster.local:8125",
+            "--statsd_prefix", "site",
         ]
 
         # Run gunicorn for the production server.

--- a/manage.py
+++ b/manage.py
@@ -164,7 +164,8 @@ class SiteManager:
             "pydis_site.wsgi:application",
             "--threads", "8",
             "-w", "4",
-            "--max-requests-jitter", "1000",
+            "--max-requests", "1000",
+            "--max-requests-jitter", "50",
             "--statsd-host", "graphite.default.svc.cluster.local:8125",
             "--statsd-prefix", "site",
         ]

--- a/manage.py
+++ b/manage.py
@@ -165,8 +165,8 @@ class SiteManager:
             "--threads", "8",
             "-w", "4",
             "--max-requests-jitter", "1000",
-            "--statsd_host", "graphite.default.svc.cluster.local:8125",
-            "--statsd_prefix", "site",
+            "--statsd-host", "graphite.default.svc.cluster.local:8125",
+            "--statsd-prefix", "site",
         ]
 
         # Run gunicorn for the production server.


### PR DESCRIPTION
Set the max requests parameter for gunicorn to restart our workers between 1 and 1000 requests to help control the damage of memory leaks. This comes after we observed over 1GB RAM usage from our site container.

A bonus feature of this PR is that it integrates the statsd client inside gunicorn to report to our graphite server so we should be able to measure metric data.
