### PR TITLE
Increase per_page to 100 for GitHub API call.

### DIFF
--- a/pydis_site/apps/home/views/home.py
+++ b/pydis_site/apps/home/views/home.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 class HomeView(View):
     """The main landing page for the website."""
 
-    github_api = "https://api.github.com/users/python-discord/repos"
+    github_api = "https://api.github.com/users/python-discord/repos?per_page=100"
     repository_cache_ttl = 3600
 
     # Which of our GitHub repos should be displayed on the front page, and in which order?


### PR DESCRIPTION
Snekbox was being banished to page 2 and we were not iterating pages, so it was not appearing in the data we got from our call to /repos. This commit changes the request to use `per_page=100`, which will work at least until we have >100 repos in our organisation.

**TLDR: Snekbox will appear on the front page after we merge this.**
