### PR TITLE
Swap Metricity verified_at for joined_at

### DIFF
--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -4,7 +4,7 @@ CREATE DATABASE metricity;
 
 CREATE TABLE users (
     id varchar,
-    verified_at timestamp,
+    joined_at timestamp,
     primary key(id)
 );
 

--- a/pydis_site/apps/api/models/bot/metricity.py
+++ b/pydis_site/apps/api/models/bot/metricity.py
@@ -28,7 +28,8 @@ class Metricity:
 
     def user(self, user_id: str) -> dict:
         """Query a user's data."""
-        columns = ["verified_at"]
+        # TODO: Swap this back to some sort of verified at date
+        columns = ["joined_at"]
         query = f"SELECT {','.join(columns)} FROM users WHERE id = '%s'"
         self.cursor.execute(query, [user_id])
         values = self.cursor.fetchone()

--- a/pydis_site/apps/api/tests/test_users.py
+++ b/pydis_site/apps/api/tests/test_users.py
@@ -407,10 +407,10 @@ class UserMetricityTests(APISubdomainTestCase):
 
     def test_get_metricity_data(self):
         # Given
-        verified_at = "foo"
+        joined_at = "foo"
         total_messages = 1
         total_blocks = 1
-        self.mock_metricity_user(verified_at, total_messages, total_blocks)
+        self.mock_metricity_user(joined_at, total_messages, total_blocks)
 
         # When
         url = reverse('bot:user-metricity-data', args=[0], host='api')
@@ -419,7 +419,7 @@ class UserMetricityTests(APISubdomainTestCase):
         # Then
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {
-            "verified_at": verified_at,
+            "joined_at": joined_at,
             "total_messages": total_messages,
             "voice_banned": False,
             "activity_blocks": total_blocks
@@ -455,12 +455,12 @@ class UserMetricityTests(APISubdomainTestCase):
                     self.assertEqual(response.status_code, 200)
                     self.assertEqual(response.json()["voice_banned"], case["voice_banned"])
 
-    def mock_metricity_user(self, verified_at, total_messages, total_blocks):
+    def mock_metricity_user(self, joined_at, total_messages, total_blocks):
         patcher = patch("pydis_site.apps.api.viewsets.bot.user.Metricity")
         self.metricity = patcher.start()
         self.addCleanup(patcher.stop)
         self.metricity = self.metricity.return_value.__enter__.return_value
-        self.metricity.user.return_value = dict(verified_at=verified_at)
+        self.metricity.user.return_value = dict(joined_at=joined_at)
         self.metricity.total_messages.return_value = total_messages
         self.metricity.total_message_blocks.return_value = total_blocks
 

--- a/pydis_site/apps/api/viewsets/bot/user.py
+++ b/pydis_site/apps/api/viewsets/bot/user.py
@@ -109,7 +109,7 @@ class UserViewSet(ModelViewSet):
 
     #### Response format
     >>> {
-    ...    "verified_at": "2020-10-06T21:54:23.540766",
+    ...    "joined_at": "2020-10-06T21:54:23.540766",
     ...    "total_messages": 2,
     ...    "voice_banned": False,
     ...    "activity_blocks": 1


### PR DESCRIPTION
Swap out the verified_at column in metricity for joined_at.

This might be temporary while we find a solution for recording accurate verified dates in future, though for now we'll keep it as joined at (hence why the response has also been changed).