### PR TITLE
Make flake8 properly run through pre-commit in PyCharm.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,6 @@ repos:
         name: Flake8
         description: This hook runs flake8 within our project's pipenv environment.
         entry: pipenv run flake8
-        language: python
+        language: system
         types: [python]
         require_serial: true


### PR DESCRIPTION
Exactly the same changes as [PR 1334 on bot](<https://github.com/python-discord/bot/pull/1334>).

An old pipenv bug was eventually resolved, breaking precommit running properly within PyCharm. Setting `language: system` removes the need to set `os.putenv('PIPENV_IGNORE_VIRTUALENVS', '1')`, since `PIPENV_IGNORE_VIRTUALENVS` now defaults to being unset.

Success with this fix is documented within this screenshot, by adding an extra newline (for a total of 3), which flake8 rejects.

![image](https://user-images.githubusercontent.com/15021300/103456095-d9aa5400-4ca7-11eb-9a01-45e0681c9384.png)
