### PR TITLE
Allow multiple nominations per users

### DIFF
--- a/pydis_site/apps/api/tests/test_nominations.py
+++ b/pydis_site/apps/api/tests/test_nominations.py
@@ -37,7 +37,7 @@ class CreationTests(APISubdomainTestCase):
         self.assertEqual(nomination.reason, data['reason'])
         self.assertEqual(nomination.active, True)
 
-    def test_returns_400_on_second_active_nomination(self):
+    def test_returns_201_on_second_active_nomination(self):
         url = reverse('bot:nomination-list', host='api')
         data = {
             'actor': self.user.id,
@@ -49,10 +49,7 @@ class CreationTests(APISubdomainTestCase):
         self.assertEqual(response1.status_code, 201)
 
         response2 = self.client.post(url, data=data)
-        self.assertEqual(response2.status_code, 400)
-        self.assertEqual(response2.json(), {
-            'active': ['There can only be one active nomination.']
-        })
+        self.assertEqual(response2.status_code, 201)
 
     def test_returns_400_for_missing_user(self):
         url = reverse('bot:nomination-list', host='api')

--- a/pydis_site/apps/api/viewsets/bot/nomination.py
+++ b/pydis_site/apps/api/viewsets/bot/nomination.py
@@ -75,8 +75,7 @@ class NominationViewSet(CreateModelMixin, RetrieveModelMixin, ListModelMixin, Ge
     Create a new, active nomination returns the created nominations.
     The `user`, `reason` and `actor` fields are required and the `user`
     and `actor` need to know by the site. Providing other valid fields
-    is not allowed and invalid fields are ignored. A `user` is only
-    allowed one active nomination at a time.
+    is not allowed and invalid fields are ignored.
 
     #### Request body
     >>> {
@@ -91,7 +90,6 @@ class NominationViewSet(CreateModelMixin, RetrieveModelMixin, ListModelMixin, Ge
     #### Status codes
     - 201: returned on success
     - 400: returned on failure for one of the following reasons:
-        - A user already has an active nomination;
         - The `user` or `actor` are unknown to the site;
         - The request contained a field that cannot be set at creation.
 
@@ -161,10 +159,6 @@ class NominationViewSet(CreateModelMixin, RetrieveModelMixin, ListModelMixin, Ge
         for field in request.data:
             if field in self.frozen_on_create:
                 raise ValidationError({field: ['This field cannot be set at creation.']})
-
-        user_id = request.data.get("user")
-        if Nomination.objects.filter(active=True, user__id=user_id).exists():
-            raise ValidationError({'active': ['There can only be one active nomination.']})
 
         serializer = self.get_serializer(
             data=ChainMap(


### PR DESCRIPTION
Removes check that doesn't allow users have more than 1 active nomination. Updated docs and tests to match with this change. Closes #445 