### PR TITLE
New error pages

### DIFF
--- a/pydis_site/static/css/error_pages.css
+++ b/pydis_site/static/css/error_pages.css
@@ -1,0 +1,66 @@
+html {
+    height: 100%;
+}
+
+body {
+    background-color: #7289DA;
+    background-image: url("https://raw.githubusercontent.com/python-discord/branding/master/logos/banner_pattern/banner_pattern.svg");
+    background-size: 128px;
+    font-family: "Hind", "Helvetica", "Arial", sans-serif;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+}
+
+h1,
+p {
+    color: black;
+    padding: 0;
+    margin: 0;
+    margin-bottom: 10px;
+}
+
+h1 {
+    margin-bottom: 15px;
+    font-size: 26px;
+}
+
+p,
+li {
+    line-height: 125%;
+}
+
+a {
+    color: #7289DA;
+}
+
+ul {
+    margin-bottom: 0;
+}
+
+li {
+    margin-top: 10px;
+}
+
+.error-box {
+    display: flex;
+    flex-direction: column;
+    max-width: 512px;
+    background-color: white;
+    border-radius: 20px;
+    overflow: hidden;
+    box-shadow: 5px 7px 40px rgba(0, 0, 0, 0.432);
+}
+
+.logo-box {
+    display: flex;
+    justify-content: center;
+    height: 80px;
+    padding: 15px;
+    background-color: #758ad4;
+}
+
+.content-box {
+    padding: 25px;
+}

--- a/pydis_site/templates/404.html
+++ b/pydis_site/templates/404.html
@@ -20,7 +20,7 @@
                 alt="Python Discord banner" />
         </div>
         <div class="content-box">
-            <h1>404 — not found</h1>
+            <h1>404 — Not Found</h1>
             <p>We couldn't find the page you're looking for. Here are a few things to try out:</p>
             <ul>
                 <li>Double check the URL. Are you sure you typed it out correctly?

--- a/pydis_site/templates/404.html
+++ b/pydis_site/templates/404.html
@@ -1,0 +1,34 @@
+{% load static %}
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>Python Discord | 404</title>
+
+    <meta charset="UTF-8">
+
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Hind:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{% static "css/error_pages.css" %}">
+</head>
+
+<body>
+    <div class="error-box">
+        <div class="logo-box">
+            <img src="https://raw.githubusercontent.com/python-discord/branding/b67897df93e572c1576a9026eb78c785a794d226/logos/logo_banner/logo_site_banner.svg"
+                alt="Python Discord banner" />
+        </div>
+        <div class="content-box">
+            <h1>404 — not found</h1>
+            <p>We couldn't find the page you're looking for. Here are a few things to try out:</p>
+            <ul>
+                <li>Double check the URL. Are you sure you typed it out correctly?
+                <li>Come join <a href="https://discord.gg/python">our Discord Server</a>. Maybe we can help you out over
+                    there
+            </ul>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/pydis_site/templates/500.html
+++ b/pydis_site/templates/500.html
@@ -1,0 +1,29 @@
+{% load static %}
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>Python Discord | 500</title>
+
+    <meta charset="UTF-8">
+
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Hind:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{% static "css/error_pages.css" %}">
+</head>
+
+<body>
+    <div class="error-box">
+        <div class="logo-box">
+            <img src="https://raw.githubusercontent.com/python-discord/branding/b67897df93e572c1576a9026eb78c785a794d226/logos/logo_banner/logo_site_banner.svg"
+                alt="Python Discord banner" />
+        </div>
+        <div class="content-box">
+            <h1>500 — internal server error</h1>
+            <p>Sorry, but something went wrong on our side of things.</p>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/pydis_site/templates/500.html
+++ b/pydis_site/templates/500.html
@@ -20,7 +20,7 @@
                 alt="Python Discord banner" />
         </div>
         <div class="content-box">
-            <h1>500 — internal server error</h1>
+            <h1>500 — Internal Server Error</h1>
             <p>Sorry, but something went wrong on our side of things.</p>
         </div>
     </div>

--- a/pydis_site/templates/500.html
+++ b/pydis_site/templates/500.html
@@ -21,7 +21,7 @@
         </div>
         <div class="content-box">
             <h1>500 — Internal Server Error</h1>
-            <p>Sorry, but something went wrong on our side of things.</p>
+            <p>Something went wrong at our end. Please try again shortly, or if the problem persists, please let us know <a href="https://discord.gg/python">on Discord</a>.</p>
         </div>
     </div>
 </body>


### PR DESCRIPTION
This PR adds pages for 404 and 500 errors on the site. They are following the same structure as the recently merged custom CF error pages (python-discord/error-pages#1).

## Preview
### 404
<img width="1409" alt="Screenshot 2021-03-01 at 17 16 07" src="https://user-images.githubusercontent.com/65498475/109525445-d23dd600-7ab1-11eb-9769-4b1acce7f200.png">

### 500
<img width="1409" alt="Screenshot 2021-03-01 at 17 17 33" src="https://user-images.githubusercontent.com/65498475/109525645-0618fb80-7ab2-11eb-94d3-10ce551139ff.png">