### PR TITLE
Add GitHub environment to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,6 +13,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     name: Deploy to Kubernetes Cluster
     runs-on: ubuntu-latest
+    environment: production
 
     steps:
       - name: Create SHA Container Tag


### PR DESCRIPTION
Implements a [GitHub Environment](https://docs.github.com/en/actions/reference/environments) to our deploy script to ensure only the `main` branch can be deployed to production.