### PR TITLE
Removes Gunicorn Import In Debug Mode

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -7,7 +7,6 @@ import time
 from typing import List
 
 import django
-import gunicorn.app.wsgiapp
 from django.contrib.auth import get_user_model
 from django.core.management import call_command, execute_from_command_line
 
@@ -155,6 +154,9 @@ class SiteManager:
         if self.debug:
             call_command("runserver", "0.0.0.0:8000")
             return
+
+        # Import gunicorn only if we aren't in debug mode.
+        import gunicorn.app.wsgiapp
 
         # Patch the arguments for gunicorn
         sys.argv = [


### PR DESCRIPTION
The placement of the gunicorn import at the top of the manage.py file means the project is unable to start if gunicorn, or one of its dependencies isn't available. That is the case on windows, which makes starting the project completely impossible without using docker.

This PR moves that import below the start command for debug mode, so gunicorn will only be imported in production mode.