### PR TITLE
Update landing page and timeline

### DIFF
--- a/pydis_site/static/css/home/index.css
+++ b/pydis_site/static/css/home/index.css
@@ -45,6 +45,10 @@ h1 {
     box-shadow: 0 14px 28px rgba(0,0,0,0.25), 0 10px 10px rgba(0,0,0,0.22);
 }
 
+#wave-hero-centered {
+    margin: auto auto;
+}
+
 #wave-hero-right img{
     border-radius: 10px;
     box-shadow: 0 1px 6px rgba(0,0,0,0.16), 0 1px 6px rgba(0,0,0,0.23);

--- a/pydis_site/templates/home/index.html
+++ b/pydis_site/templates/home/index.html
@@ -92,7 +92,7 @@
         <section id="showcase" class="column is-half-desktop has-text-centered">
           <article class="box">
 
-            <header class="title">New Timeline!</header>
+            <header class="title">Interactive timeline</header>
 
             <div class="mini-timeline">
               <i class="fa fa-asterisk"></i>
@@ -104,7 +104,7 @@
             </div>
 
             <p class="subtitle">
-              Start from our humble beginnings to discover the events that made our community what it is today.
+              Discover the history of our community, and learn about the events that made our community what it is today.
             </p>
 
             <div class="buttons are-large is-centered">

--- a/pydis_site/templates/home/index.html
+++ b/pydis_site/templates/home/index.html
@@ -29,7 +29,7 @@
         <div class="columns is-variable is-8">
 
           {# Embedded Welcome video #}
-          <div id="wave-hero-left" class="column is-half">
+          <div id="wave-hero-centered" class="column is-half">
             <div class="force-aspect-container">
               <iframe
               class="force-aspect-content"
@@ -50,12 +50,6 @@
               ></iframe>
             </div>
           </div>
-
-          {# Right side content #}
-          <div id="wave-hero-right" class="column is-half">
-            <img src="{% static "images/events/100k.png" %}" alt="100K members!">
-          </div>
-
         </div>
       </div>
 

--- a/pydis_site/templates/home/timeline.html
+++ b/pydis_site/templates/home/timeline.html
@@ -3,53 +3,53 @@
 
 {% block title %}Timeline{% endblock %}
 {% block head %}
-<link rel="stylesheet" href="{% static "css/home/timeline.css" %}">
-<link rel="stylesheet" href="{% static "css/home/index.css" %}">
+  <link rel="stylesheet" href="{% static "css/home/timeline.css" %}">
+  <link rel="stylesheet" href="{% static "css/home/index.css" %}">
 {% endblock %}
 
 {% block content %}
-{% include "base/navbar.html" %}
+  {% include "base/navbar.html" %}
 
-<section class="cd-timeline js-cd-timeline">
+  <section class="cd-timeline js-cd-timeline">
     <div class="container max-width-lg cd-timeline__container">
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img cd-timeline__img--picture">
-                <img src="{% static "images/timeline/cd-icon-picture.svg" %}" alt="Picture">
-            </div>
-
-            <div class="cd-timeline__content text-component">
-                <h2>Python Discord is created</h2>
-                <p class="color-contrast-medium"><strong>joe</strong> becomes one of the owners around 3 days after it
-                    is created, and <strong>lemon</strong> joins the owner team later in the year, when the community
-                    has around 300 members.</p>
-
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Jan 8th, 2017</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img cd-timeline__img--picture">
+          <img src="{% static "images/timeline/cd-icon-picture.svg" %}" alt="Picture">
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-dark-blue cd-timeline__img--picture">
-                <i class="fa fa-users"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>Python Discord is created</h2>
+          <p class="color-contrast-medium"><strong>joe</strong> becomes one of the owners around 3 days after it
+            is created, and <strong>lemon</strong> joins the owner team later in the year, when the community
+            has around 300 members.</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>Python Discord hits 1,000 members</h2>
-                <p class="color-contrast-medium">Our main source of new users at this point is a post on Reddit that
-                    happens to get very good SEO. We are one of the top 10 search engine hits for the search term
-                    "python discord".</p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Jan 8th, 2017</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Nov 10th, 2017</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-dark-blue cd-timeline__img--picture">
+          <i class="fa fa-users"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img cd-timeline__img--picture">
-                <img src={% static "images/timeline/cd-icon-picture.svg" %} alt="Picture">
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>Python Discord hits 1,000 members</h2>
+          <p class="color-contrast-medium">Our main source of new users at this point is a post on Reddit that
+            happens to get very good SEO. We are one of the top 10 search engine hits for the search term
+            "python discord".</p>
+
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Nov 10th, 2017</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img cd-timeline__img--picture">
+          <img src={% static "images/timeline/cd-icon-picture.svg" %} alt="Picture">
+        </div>
 
             <div class="cd-timeline__content text-component">
                 <h2>Our logo is born. Thanks @Aperture!</h2>
@@ -57,464 +57,638 @@
                         src="https://raw.githubusercontent.com/python-discord/branding/main/logos/logo_banner/logo_site_banner.svg">
                 </p>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Feb 3rd, 2018</span>
-                </div>
-            </div>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Feb 3rd, 2018</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-dark-blue cd-timeline__img--picture">
+          <i class="fa fa-users"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-dark-blue cd-timeline__img--picture">
-                <i class="fa fa-users"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>PyDis hits 2,000 members; pythondiscord.com and @Python are live</h2>
+          <p class="color-contrast-medium">The public moderation bot we're using at the time, Rowboat, announces
+            it will be shutting down. We decide that we'll write our own bot to handle moderation, so that we
+            can have more control over its features. We also buy a domain and start making a website in Flask.
+          </p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>PyDis hits 2,000 members; pythondiscord.com and @Python are live</h2>
-                <p class="color-contrast-medium">The public moderation bot we're using at the time, Rowboat, announces
-                    it will be shutting down. We decide that we'll write our own bot to handle moderation, so that we
-                    can have more control over its features. We also buy a domain and start making a website in Flask.
-                </p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Mar 4th, 2018</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Mar 4th, 2018</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-blue cd-timeline__img--picture">
+          <i class="fa fa-dice"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-blue cd-timeline__img--picture">
-                <i class="fa fa-dice"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>First code jam with the theme “snakes”</h2>
+          <p class="color-contrast-medium">Our very first Code Jam attracts a handful of users who work in random
+            teams of 2. We ask our participants to write a snake-themed Discord bot. Most of the code written
+            for this jam still lives on in SeasonalBot, and you can play with it by using the
+            <code>.snakes</code> command. For more information on this event, see <a
+                href="https://pythondiscord.com/pages/code-jams/code-jam-1-snakes-bot/">the event page</a></p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>First code jam with the theme “snakes”</h2>
-                <p class="color-contrast-medium">Our very first Code Jam attracts a handful of users who work in random
-                    teams of 2. We ask our participants to write a snake-themed Discord bot. Most of the code written
-                    for this jam still lives on in SeasonalBot, and you can play with it by using the
-                    <code>.snakes</code> command. For more information on this event, see <a
-                        href="https://pythondiscord.com/pages/code-jams/code-jam-1-snakes-bot/">the event page</a></p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Mar 23rd, 2018</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Mar 23rd, 2018</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-lime cd-timeline__img--picture">
+          <i class="fa fa-scroll"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-lime cd-timeline__img--picture">
-                <i class="fa fa-scroll"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>The privacy policy is created</h2>
+          <p class="color-contrast-medium">Since data privacy is quite important to us, we create a privacy page
+            pretty much as soon as our new bot and site starts collecting some data. To this day, we keep <a
+                href="https://pythondiscord.com/pages/privacy/">our privacy policy</a> up to date with all
+            changes, and since April 2020 we've started doing <a
+                href="https://pythondiscord.com/pages/data-reviews/">monthly data reviews</a>.</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>The privacy policy is created</h2>
-                <p class="color-contrast-medium">Since data privacy is quite important to us, we create a privacy page
-                    pretty much as soon as our new bot and site starts collecting some data. To this day, we keep <a
-                        href="https://pythondiscord.com/pages/privacy/">our privacy policy</a> up to date with all
-                    changes, and since April 2020 we've started doing <a
-                        href="https://pythondiscord.com/pages/data-reviews/">monthly data reviews</a>.</p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">May 21st, 2018</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">May 21st, 2018</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-pink cd-timeline__img--picture">
+          <i class="fa fa-handshake"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-pink cd-timeline__img--picture">
-                <i class="fa fa-handshake"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>Do You Even Python and PyDis merger</h2>
+          <p class="color-contrast-medium">At this point in time, there are only two serious Python communities on
+            Discord - Ours, and one called Do You Even Python. We approach the owners of DYEP with a bold
+            proposal - let's shut down their community, replace it with links to ours, and in return we will let
+            their staff join our staff. This gives us a big boost in members, and eventually leads to @eivl and
+            @Mr. Hemlock joining our Admin team</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>Do You Even Python and PyDis merger</h2>
-                <p class="color-contrast-medium">At this point in time, there are only two serious Python communities on
-                    Discord - Ours, and one called Do You Even Python. We approach the owners of DYEP with a bold
-                    proposal - let's shut down their community, replace it with links to ours, and in return we will let
-                    their staff join our staff. This gives us a big boost in members, and eventually leads to @eivl and
-                    @Mr. Hemlock joining our Admin team</p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Jun 9th, 2018</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Jun 9th, 2018</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-dark-blue cd-timeline__img--picture">
+          <i class="fa fa-users"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-dark-blue cd-timeline__img--picture">
-                <i class="fa fa-users"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>PyDis hits 5,000 members and partners with r/Python</h2>
+          <p class="color-contrast-medium">As we continue to grow, we approach the r/Python subreddit and ask to
+            become their official Discord community. They agree, and we become listed in their sidebar, giving
+            us yet another source of new members.</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>PyDis hits 5,000 members and partners with r/Python</h2>
-                <p class="color-contrast-medium">As we continue to grow, we approach the r/Python subreddit and ask to
-                    become their official Discord community. They agree, and we become listed in their sidebar, giving
-                    us yet another source of new members.</p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Jun 20th, 2018</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Jun 20th, 2018</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-pink cd-timeline__img--picture">
+          <i class="fa fa-handshake"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-pink cd-timeline__img--picture">
-                <i class="fa fa-handshake"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>PyDis is now partnered with Discord; the vanity URL discord.gg/python is created</h2>
+          <p class="color-contrast-medium">After being rejected for their Partner program several times, we
+            finally get approved. The recent partnership with the r/Python subreddit plays a significant role in
+            qualifying us for this partnership.</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>PyDis is now partnered with Discord; the vanity URL discord.gg/python is created</h2>
-                <p class="color-contrast-medium">After being rejected for their Partner program several times, we
-                    finally get approved. The recent partnership with the r/Python subreddit plays a significant role in
-                    qualifying us for this partnership.</p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Jul 10th, 2018</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Jul 10th, 2018</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-blue cd-timeline__img--picture">
+          <i class="fa fa-dice"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-blue cd-timeline__img--picture">
-                <i class="fa fa-dice"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>First Hacktoberfest PyDis event; @SeasonalBot is created</h2>
+          <p class="color-contrast-medium">We create a second bot for our community and fill it up with simple,
+            fun and relatively easy issues. The idea is to create an approachable arena for our members to cut
+            their open-source teeth on, and to provide lots of help and hand-holding for those who get stuck.
+            We're training our members to be productive contributors in the open-source ecosystem.</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>First Hacktoberfest PyDis event; @SeasonalBot is created</h2>
-                <p class="color-contrast-medium">We create a second bot for our community and fill it up with simple,
-                    fun and relatively easy issues. The idea is to create an approachable arena for our members to cut
-                    their open-source teeth on, and to provide lots of help and hand-holding for those who get stuck.
-                    We're training our members to be productive contributors in the open-source ecosystem.</p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Oct 1st, 2018</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Oct 1st, 2018</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-dark-blue cd-timeline__img--picture">
+          <i class="fa fa-users"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-dark-blue cd-timeline__img--picture">
-                <i class="fa fa-users"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>PyDis hits 10,000 members</h2>
+          <p class="color-contrast-medium">We partner with RLBot, move from GitLab to GitHub, and start putting
+            together the first Advent of Code event.</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>PyDis hits 10,000 members</h2>
-                <p class="color-contrast-medium">We partner with RLBot, move from GitLab to GitHub, and start putting
-                    together the first Advent of Code event.</p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Nov 24th, 2018</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Nov 24th, 2018</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-orange cd-timeline__img--picture">
+          <i class="fa fa-code"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-orange cd-timeline__img--picture">
-                <i class="fa fa-code"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>django-simple-bulma is released on PyPi</h2>
+          <p class="color-contrast-medium">Our very first package on PyPI, <a
+              href="https://pypi.org/project/django-simple-bulma/">django-simple-bulma</a> is a package that
+            sets up the Bulma CSS framework for your Django application and lets you configure everything in
+            settings.py.</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>django-simple-bulma is released on PyPi</h2>
-                <p class="color-contrast-medium">Our very first package on PyPI, <a
-                        href="https://pypi.org/project/django-simple-bulma/">django-simple-bulma</a> is a package that
-                    sets up the Bulma CSS framework for your Django application and lets you configure everything in
-                    settings.py.</p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Dec 19th, 2018</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Dec 19th, 2018</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-dark-blue cd-timeline__img--picture">
+          <i class="fa fa-users"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-dark-blue cd-timeline__img--picture">
-                <i class="fa fa-users"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>PyDis hits 15,000 members; the “hot ones special” video is released</h2>
+          <div class="force-aspect-container">
+            <iframe class="force-aspect-content" src="https://www.youtube.com/embed/DIBXg8Qh7bA" frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+          </div>
 
-            <div class="cd-timeline__content text-component">
-                <h2>PyDis hits 15,000 members; the “hot ones special” video is released</h2>
-                <div class="force-aspect-container">
-                    <iframe class="force-aspect-content" src="https://www.youtube.com/embed/DIBXg8Qh7bA" frameborder="0"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                        allowfullscreen></iframe>
-                </div>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Apr 8th, 2019</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Apr 8th, 2019</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-orange cd-timeline__img--picture">
+          <i class="fa fa-code"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-orange cd-timeline__img--picture">
-                <i class="fa fa-code"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>The Django rewrite of pythondiscord.com is now live!</h2>
+          <p class="color-contrast-medium">The site is getting more and more complex, and it's time for a rewrite.
+            We decide to go for a different stack, and build a website based on Django, DRF, Bulma and
+            PostgreSQL.</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>The Django rewrite of pythondiscord.com is now live!</h2>
-                <p class="color-contrast-medium">The site is getting more and more complex, and it's time for a rewrite.
-                    We decide to go for a different stack, and build a website based on Django, DRF, Bulma and
-                    PostgreSQL.</p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Sep 15, 2019</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Sep 15, 2019</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-lime cd-timeline__img--picture">
+          <i class="fa fa-scroll"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-lime cd-timeline__img--picture">
-                <i class="fa fa-scroll"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>The code of conduct is created</h2>
+          <p class="color-contrast-medium">Inspired by the Adafruit, Rust and Django communities, an essential
+            community pillar is created; Our <a href="https://pythondiscord.com/pages/code-of-conduct/">Code of
+              Conduct.</a></p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>The code of conduct is created</h2>
-                <p class="color-contrast-medium">Inspired by the Adafruit, Rust and Django communities, an essential
-                    community pillar is created; Our <a href="https://pythondiscord.com/pages/code-of-conduct/">Code of
-                        Conduct.</a></p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Oct 26th, 2019</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Oct 26th, 2019</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img cd-timeline__img--picture">
+          <img src={% static "images/timeline/cd-icon-picture.svg" %} alt="Picture">
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img cd-timeline__img--picture">
-                <img src={% static "images/timeline/cd-icon-picture.svg" %} alt="Picture">
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>Ves Zappa becomes an owner</h2>
+          <p class="color-contrast-medium">After being a long time active contributor to our projects and the driving
+            force behind our events, Ves Zappa joined the Owners team alongside joe & lemon.</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>Ves Zappa becomes an owner</h2>
-                <p class="color-contrast-medium">After being a long time active contributor to our projects and the driving force behind our events, Ves Zappa joined the Owners team alongside joe & lemon.</p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Sept 22nd, 2019</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Sept 22nd, 2019</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-dark-blue cd-timeline__img--picture">
+          <i class="fa fa-users"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-dark-blue cd-timeline__img--picture">
-                <i class="fa fa-users"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>PyDis hits 30,000 members</h2>
+          <p class="color-contrast-medium">More than tripling in size since the year before, the community hits
+            30000 users. At this point, we're probably the largest Python chat community on the planet.</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>PyDis hits 30,000 members</h2>
-                <p class="color-contrast-medium">More than tripling in size since the year before, the community hits
-                    30000 users. At this point, we're probably the largest Python chat community on the planet.</p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Dec 22nd, 2019</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Dec 22nd, 2019</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-blue cd-timeline__img--picture">
+          <i class="fa fa-dice"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-blue cd-timeline__img--picture">
-                <i class="fa fa-dice"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>PyDis sixth code jam with the theme “Ancient technology” and the technology Kivy</h2>
+          <p class="color-contrast-medium">Our Code Jams are becoming an increasingly big deal, and the Kivy core
+            developers join us to judge the event and help out our members during the event. One of them,
+            @tshirtman, even joins our staff!</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>PyDis sixth code jam with the theme “Ancient technology” and the technology Kivy</h2>
-                <p class="color-contrast-medium">Our Code Jams are becoming an increasingly big deal, and the Kivy core
-                    developers join us to judge the event and help out our members during the event. One of them,
-                    @tshirtman, even joins our staff!</p>
+          <div class="force-aspect-container">
+            <iframe class="force-aspect-content" src="https://www.youtube.com/embed/8fbZsGrqBzo" frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+          </div>
 
-                <div class="force-aspect-container">
-                    <iframe class="force-aspect-content" src="https://www.youtube.com/embed/8fbZsGrqBzo" frameborder="0"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                        allowfullscreen></iframe>
-                </div>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Jan 17, 2020</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Jan 17, 2020</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-green cd-timeline__img--picture">
+          <i class="fa fa-comments"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-green cd-timeline__img--picture">
-                <i class="fa fa-comments"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>The new help channel system is live</h2>
+          <p class="color-contrast-medium">We release our dynamic help-channel system, which allows you to claim
+            your very own help channel instead of fighting over the static help channels. We release a <a
+                href="https://pythondiscord.com/pages/resources/guides/help-channels/">Help Channel Guide</a> to
+            help our members fully understand how the system works.</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>The new help channel system is live</h2>
-                <p class="color-contrast-medium">We release our dynamic help-channel system, which allows you to claim
-                    your very own help channel instead of fighting over the static help channels. We release a <a
-                        href="https://pythondiscord.com/pages/resources/guides/help-channels/">Help Channel Guide</a> to
-                    help our members fully understand how the system works.</p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Apr 5th, 2020</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Apr 5th, 2020</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-dark-blue cd-timeline__img--picture">
+          <i class="fa fa-users"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-dark-blue cd-timeline__img--picture">
-                <i class="fa fa-users"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>Python Discord hits 40,000 members, and is now bigger than Liechtenstein.</h2>
+          <p class="color-contrast-medium"><img
+              src="https://cdn.discordapp.com/attachments/354619224620138496/699666518476324954/unknown.png">
+          </p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>Python Discord hits 40,000 members, and is now bigger than Liechtenstein.</h2>
-                <p class="color-contrast-medium"><img
-                        src="https://cdn.discordapp.com/attachments/354619224620138496/699666518476324954/unknown.png">
-                </p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Apr 14, 2020</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Apr 14, 2020</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-purple cd-timeline__img--picture">
+          <i class="fa fa-gamepad"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-purple cd-timeline__img--picture">
-                <i class="fa fa-gamepad"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>PyDis Game Jam 2020 with the “Three of a Kind” theme and Arcade as the technology</h2>
+          <p class="color-contrast-medium">The creator of Arcade, Paul Vincent Craven, joins us as a judge.
+            Several of the Code Jam participants also end up getting involved contributing to the Arcade
+            repository.</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>PyDis Game Jam 2020 with the “Three of a Kind” theme and Arcade as the technology</h2>
-                <p class="color-contrast-medium">The creator of Arcade, Paul Vincent Craven, joins us as a judge.
-                    Several of the Code Jam participants also end up getting involved contributing to the Arcade
-                    repository.</p>
+          <div class="force-aspect-container">
+            <iframe class="force-aspect-content" src="https://www.youtube.com/embed/KkLXMvKfEgs" frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+          </div>
 
-                <div class="force-aspect-container">
-                    <iframe class="force-aspect-content" src="https://www.youtube.com/embed/KkLXMvKfEgs" frameborder="0"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                        allowfullscreen></iframe>
-                </div>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Apr 17th, 2020</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Apr 17th, 2020</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-green cd-timeline__img--picture">
+          <i class="fa fa-comments"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-green cd-timeline__img--picture">
-                <i class="fa fa-comments"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>ModMail is now live</h2>
+          <p class="color-contrast-medium">Having originally planned to write our own ModMail bot from scratch, we
+            come across an exceptionally good <a href="https://github.com/kyb3r/modmail">ModMail bot by
+              kyb3r</a> and decide to just self-host that one instead.</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>ModMail is now live</h2>
-                <p class="color-contrast-medium">Having originally planned to write our own ModMail bot from scratch, we
-                    come across an exceptionally good <a href="https://github.com/kyb3r/modmail">ModMail bot by
-                        kyb3r</a> and decide to just self-host that one instead.</p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">May 25th, 2020</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">May 25th, 2020</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-pink cd-timeline__img--picture">
+          <i class="fa fa-handshake"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-pink cd-timeline__img--picture">
-                <i class="fa fa-handshake"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>Python Discord is now listed on python.org/community</h2>
+          <p class="color-contrast-medium">After working towards this goal for months, we finally work out an
+            arrangement with the PSF that allows us to be listed on that most holiest of websites:
+            https://python.org/. <a href="https://youtu.be/yciX2meIkXI?t=3">There was much rejoicing.</a></p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>Python Discord is now listed on python.org/community</h2>
-                <p class="color-contrast-medium">After working towards this goal for months, we finally work out an
-                    arrangement with the PSF that allows us to be listed on that most holiest of websites:
-                    https://python.org/. <a href="https://youtu.be/yciX2meIkXI?t=3">There was much rejoicing.</a></p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">May 28th, 2020</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">May 28th, 2020</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-red cd-timeline__img--picture">
+          <i class="fa fa-chart-bar"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-red cd-timeline__img--picture">
-                <i class="fa fa-chart-bar"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>Python Discord Public Statistics are now live</h2>
+          <p class="color-contrast-medium">After getting numerous requests to publish beautiful data on member
+            count and channel use, we create <a href="https://stats.pythondiscord.com/">stats.pythondiscord.com</a> for
+            all to enjoy.</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>Python Discord Public Statistics are now live</h2>
-                <p class="color-contrast-medium">After getting numerous requests to publish beautiful data on member
-                    count and channel use, we create <a href="https://stats.pythondiscord.com/">stats.pythondiscord.com</a> for all to enjoy.</p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Jun 4th, 2020</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Jun 4th, 2020</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-blue cd-timeline__img--picture">
+          <i class="fa fa-dice"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-blue cd-timeline__img--picture">
-                <i class="fa fa-dice"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>PyDis summer code jam 2020 with the theme “Early Internet” and Django as the technology</h2>
+          <p class="color-contrast-medium">Sponsored by the Django Software Foundation and JetBrains, the Summer
+            Code Jam for 2020 attracts hundreds of participants, and sees the creation of some fantastic
+            projects. Check them out in our judge stream below:</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>PyDis summer code jam 2020 with the theme “Early Internet” and Django as the technology</h2>
-                <p class="color-contrast-medium">Sponsored by the Django Software Foundation and JetBrains, the Summer
-                    Code Jam for 2020 attracts hundreds of participants, and sees the creation of some fantastic
-                    projects. Check them out in our judge stream below:</p>
+          <div class="force-aspect-container">
+            <iframe class="force-aspect-content" src="https://www.youtube.com/embed/OFtm8f2iu6c" frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+          </div>
 
-                <div class="force-aspect-container">
-                    <iframe class="force-aspect-content" src="https://www.youtube.com/embed/OFtm8f2iu6c" frameborder="0"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                        allowfullscreen></iframe>
-                </div>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Jul 31st, 2020</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Jul 31st, 2020</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-pink cd-timeline__img--picture">
+          <i class="fa fa-handshake"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-pink cd-timeline__img--picture">
-                <i class="fa fa-handshake"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>Python Discord is now the new home of the PyWeek event!</h2>
+          <p class="color-contrast-medium">PyWeek, a game jam that has been running since 2005, joins Python
+            Discord as one of our official events. Find more information about PyWeek on <a
+                href="https://pyweek.org/">their official website</a>.</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>Python Discord is now the new home of the PyWeek event!</h2>
-                <p class="color-contrast-medium">PyWeek, a game jam that has been running since 2005, joins Python
-                    Discord as one of our official events. Find more information about PyWeek on <a
-                        href="https://pyweek.org/">their official website</a>.</p>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Aug 16th, 2020</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Aug 16th, 2020</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img cd-timeline__img--picture">
+          <img src="{% static "images/timeline/cd-icon-picture.svg" %}" alt="Picture">
         </div>
 
-	<div class="cd-timeline__block">
-            <div class="cd-timeline__img cd-timeline__img--picture">
-                <img src="{% static "images/timeline/cd-icon-picture.svg" %}" alt="Picture">
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>Python Discord hosts the 2020 CPython Core Developer Q&A</h2>
+          <div class="force-aspect-container">
+            <iframe class="force-aspect-content" src="https://www.youtube.com/embed/gXMdfBTcOfQ" frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+          </div>
 
-            <div class="cd-timeline__content text-component">
-                <h2>Python Discord hosts the 2020 CPython Core Developer Q&A</h2>
-                <div class="force-aspect-container">
-                    <iframe class="force-aspect-content" src="https://www.youtube.com/embed/gXMdfBTcOfQ" frameborder="0"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                        allowfullscreen></iframe>
-                </div>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Oct 21st, 2020</span>
+          </div>
+        </div>
+      </div>
 
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Oct 21st, 2020</span>
-                </div>
-            </div>
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-dark-blue cd-timeline__img--picture">
+          <i class="fa fa-users"></i>
         </div>
 
-        <div class="cd-timeline__block">
-            <div class="cd-timeline__img pastel-dark-blue cd-timeline__img--picture">
-                <i class="fa fa-users"></i>
-            </div>
+        <div class="cd-timeline__content text-component">
+          <h2>Python Discord hits 100,000 members!</h2>
+          <p class="color-contrast-medium">Only six months after hitting 40,000 users, we hit 100,000 users. A
+            monumental milestone,
+            and one we're very proud of. To commemorate it, we create this timeline.</p>
 
-            <div class="cd-timeline__content text-component">
-                <h2>Python Discord hits 100,000 members.</h2>
-                <p class="color-contrast-medium">After years of hard work, we hit 100,000 users. A monumental milestone,
-                    and one we're very proud of. To commemorate it, we create this timeline.</p>
-
-                <div class="flex justify-between items-center">
-                    <span class="cd-timeline__date">Oct 22nd, 2020</span>
-                </div>
-            </div>
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Oct 22nd, 2020</span>
+          </div>
         </div>
+      </div>
+
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-orange cd-timeline__img--picture">
+          <i class="fa fa-wrench"></i>
+        </div>
+
+        <div class="cd-timeline__content text-component">
+          <h2>We migrate all our infrastructure to Kubernetes</h2>
+          <p class="color-contrast-medium">As our tech stack grows, we decide to migrate all our services over to a
+            container orchestration paradigm via Kubernetes. This gives us better control and scalability.
+            <b>Joe Banks</b> takes on the role as DevOps Lead.
+          </p>
+
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Nov 29th, 2020</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-red cd-timeline__img--picture">
+          <i class="fa fa-snowflake-o"></i>
+        </div>
+
+        <div class="cd-timeline__content text-component">
+          <h2>Advent of Code attracts hundreds of participants</h2>
+          <p class="color-contrast-medium">
+            A total of 443 Python Discord members sign up to be part of
+            <a href="https://adventofcode.com/">Eric Wastl's excellent Advent of Code event</a>.
+            As always, we provide dedicated announcements, scoreboards, bot commands and channels for our members
+            to enjoy the event in.
+
+          </p>
+
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">December 1st - 25th, 2020</span>
+          </div>
+        </div>
+      </div>
+
+
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-blue cd-timeline__img--picture">
+          <i class="fa fa-music"></i>
+        </div>
+
+        <div class="cd-timeline__content text-component">
+          <h2>We release The PEP 8 song</h2>
+          <p class="color-contrast-medium">We release the PEP 8 song on our YouTube channel, which finds tens of
+            thousands of listeners!</p>
+
+          <div class="force-aspect-container">
+            <iframe class="force-aspect-content" src="https://www.youtube.com/embed/hgI0p1zf31k" frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+          </div>
+
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">February 8th, 2021</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-dark-blue cd-timeline__img--picture">
+          <i class="fa fa-users"></i>
+        </div>
+
+        <div class="cd-timeline__content text-component">
+          <h2>We now have 150,000 members!</h2>
+          <p class="color-contrast-medium">Our growth continues to accelerate.</p>
+
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Feb 18th, 2021</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-green cd-timeline__img--picture">
+          <i class="fa fa-microphone"></i>
+        </div>
+
+        <div class="cd-timeline__content text-component">
+          <h2>Lemon on Talk Python To Me</h2>
+          <p class="color-contrast-medium">Lemon goes on the Talk Python to Me podcast to discuss the history of Python
+            Discord,
+            the critical importance of culture, and how to run a massive community. You can find the episode
+            <a href="https://talkpython.fm/episodes/show/305/python-community-at-python-discord"> at talkpython.fm</a>.
+          </p>
+
+          <iframe width="100%" height="166" scrolling="no" frameborder="no"
+               src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/996083146&color=ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false">
+          </iframe>
+
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Mar 1st, 2021</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-pink cd-timeline__img--picture">
+          <i class="fa fa-microphone"></i>
+        </div>
+
+        <div class="cd-timeline__content text-component">
+          <h2>Lemon on Teaching Python</h2>
+          <p class="color-contrast-medium">Lemon goes on the Teaching Python podcast to discuss how the pandemic has
+            changed the way we learn, and what role communities like Python Discord can play in this new world.
+            You can find the episode <a href="https://teachingpython.fm/63"> at teachingpython.fm</a>.
+          </p>
+
+          <iframe width="100%" height="166" frameborder="0" scrolling="no"
+                src="https://player.fireside.fm/v2/UIYXtbeL+qOjGAsKi?theme=dark"
+          ></iframe>
+
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Mar 13th, 2021</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-purple cd-timeline__img--picture">
+          <i class="fa fa-comment"></i>
+        </div>
+
+        <div class="cd-timeline__content text-component">
+          <h2>New feature: Weekly discussion channel</h2>
+          <p class="color-contrast-medium">Every week (or two weeks), we'll be posting a new topic to discuss in a
+            channel called <b>#weekly-topic-discussion</b>. Our inaugural topic is a PyCon talk by Anthony Shaw called
+            <b>Wily Python: Writing simpler and more maintainable Python.</b></a>.
+          </p>
+
+          <div class="force-aspect-container">
+            <iframe class="force-aspect-content" src="https://www.youtube.com/embed/dqdsNoApJ80" frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+          </div>
+
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Mar 13th, 2021</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="cd-timeline__block">
+        <div class="cd-timeline__img pastel-red cd-timeline__img--picture">
+          <i class="fa fa-youtube-play"></i>
+        </div>
+
+        <div class="cd-timeline__content text-component">
+          <h2>Summer Code Jam 2020 Highlights</h2>
+          <p class="color-contrast-medium">
+            We release a new video to our YouTube showing the best projects from the Summer Code Jam 2020.
+            Better late than never!
+          </p>
+
+          <div class="force-aspect-container">
+            <iframe class="force-aspect-content" src="https://www.youtube.com/embed/g9cnp4W0P54" frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+          </div>
+
+          <div class="flex justify-between items-center">
+            <span class="cd-timeline__date">Mar 21st, 2021</span>
+          </div>
+        </div>
+      </div>
+
     </div>
-</section>
+  </section>
 
-<script src="{% static "js/timeline/main.js" %}"></script>
+  <script src="{% static "js/timeline/main.js" %}"></script>
 {% endblock %}


### PR DESCRIPTION
This PR makes two changes:
- Removes the 100K banner from the landing page. It's no longer relevant, we're at like 165K.
- Adds new stuff to the timeline.

# Landing page
I've simply removed the banner element and centered the welcome video.

![image](https://user-images.githubusercontent.com/2098517/112388586-a51cc600-8cf3-11eb-9e72-b9a7b9e7a075.png)


# Timeline
![image](https://user-images.githubusercontent.com/2098517/112388633-b6fe6900-8cf3-11eb-8837-eb383e6012c6.png)
![image](https://user-images.githubusercontent.com/2098517/112388642-bd8ce080-8cf3-11eb-83e4-8ae2681b26b8.png)
