### PR TITLE
Use real names in the timeline

### DIFF
--- a/pydis_site/templates/home/timeline.html
+++ b/pydis_site/templates/home/timeline.html
@@ -90,7 +90,7 @@
           <h2>First code jam with the theme “snakes”</h2>
           <p class="color-contrast-medium">Our very first Code Jam attracts a handful of users who work in random
             teams of 2. We ask our participants to write a snake-themed Discord bot. Most of the code written
-            for this jam still lives on in SeasonalBot, and you can play with it by using the
+            for this jam still lives on in Sir Lancebot, and you can play with it by using the
             <code>.snakes</code> command. For more information on this event, see <a
                 href="https://pythondiscord.com/pages/code-jams/code-jam-1-snakes-bot/">the event page</a></p>
 
@@ -178,7 +178,7 @@
         </div>
 
         <div class="cd-timeline__content text-component">
-          <h2>First Hacktoberfest PyDis event; @SeasonalBot is created</h2>
+          <h2>First Hacktoberfest PyDis event; @Sir Lancebot is created</h2>
           <p class="color-contrast-medium">We create a second bot for our community and fill it up with simple,
             fun and relatively easy issues. The idea is to create an approachable arena for our members to cut
             their open-source teeth on, and to provide lots of help and hand-holding for those who get stuck.

--- a/pydis_site/templates/home/timeline.html
+++ b/pydis_site/templates/home/timeline.html
@@ -19,8 +19,8 @@
 
         <div class="cd-timeline__content text-component">
           <h2>Python Discord is created</h2>
-          <p class="color-contrast-medium"><strong>joe</strong> becomes one of the owners around 3 days after it
-            is created, and <strong>lemon</strong> joins the owner team later in the year, when the community
+          <p class="color-contrast-medium"><strong>Joe Banks</strong> becomes one of the owners around 3 days after it
+            is created, and <strong>Leon Sandøy</strong> joins the owner team later in the year, when the community
             has around 300 members.</p>
 
           <div class="flex justify-between items-center">
@@ -283,9 +283,9 @@
         </div>
 
         <div class="cd-timeline__content text-component">
-          <h2>Ves Zappa becomes an owner</h2>
+          <h2>Sebastiaan Zeef becomes an owner</h2>
           <p class="color-contrast-medium">After being a long time active contributor to our projects and the driving
-            force behind our events, Ves Zappa joined the Owners team alongside joe & lemon.</p>
+            force behind many of our events, Sebastiaan Zeef joins the Owners Team alongside Joe & Leon.</p>
 
           <div class="flex justify-between items-center">
             <span class="cd-timeline__date">Sept 22nd, 2019</span>
@@ -600,11 +600,10 @@
         </div>
 
         <div class="cd-timeline__content text-component">
-          <h2>Lemon on Talk Python To Me</h2>
-          <p class="color-contrast-medium">Lemon goes on the Talk Python to Me podcast to discuss the history of Python
-            Discord,
-            the critical importance of culture, and how to run a massive community. You can find the episode
-            <a href="https://talkpython.fm/episodes/show/305/python-community-at-python-discord"> at talkpython.fm</a>.
+          <h2>Leon Sandøy appears on Talk Python To Me</h2>
+          <p class="color-contrast-medium">Leon goes on the Talk Python to Me podcast with Michael Kennedy
+            to discuss the history of Python Discord, the critical importance of culture, and how to run a massive
+            community. You can find the episode <a href="https://talkpython.fm/episodes/show/305/python-community-at-python-discord"> at talkpython.fm</a>.
           </p>
 
           <iframe width="100%" height="166" scrolling="no" frameborder="no"
@@ -623,8 +622,8 @@
         </div>
 
         <div class="cd-timeline__content text-component">
-          <h2>Lemon on Teaching Python</h2>
-          <p class="color-contrast-medium">Lemon goes on the Teaching Python podcast to discuss how the pandemic has
+          <h2>We're on the Teaching Python podcast!</h2>
+          <p class="color-contrast-medium">Leon joins Sean and Kelly on the Teaching Python podcast to discuss how the pandemic has
             changed the way we learn, and what role communities like Python Discord can play in this new world.
             You can find the episode <a href="https://teachingpython.fm/63"> at teachingpython.fm</a>.
           </p>

--- a/pydis_site/templates/home/timeline.html
+++ b/pydis_site/templates/home/timeline.html
@@ -20,7 +20,7 @@
         <div class="cd-timeline__content text-component">
           <h2>Python Discord is created</h2>
           <p class="color-contrast-medium"><strong>Joe Banks</strong> becomes one of the owners around 3 days after it
-            is created, and <strong>Leon Sandøy</strong> joins the owner team later in the year, when the community
+            is created, and <strong>Leon Sandøy</strong> (lemon) joins the owner team later in the year, when the community
             has around 300 members.</p>
 
           <div class="flex justify-between items-center">


### PR DESCRIPTION
Using nicknames like Ves Zappa and Lemon doesn't always feel appropriate, so I've replaced some of those references with real names.

This PR also updates references to SeasonalBot to Sir Lancebot.