### PR TITLE
Migrate GHCR_TOKEN -> GITHUB_TOKEN in Docker build action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,8 +38,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USER }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Build the container, including an inline cache manifest to
       # allow us to use the registry as a cache source.


### PR DESCRIPTION
GITHUB_TOKEN has now enough permissions to be used for pushing to GHCR, so we don't need PAT anymore. Also, use `repository_owner` instead of the secret of username.