### PR TITLE
Add timeline to navbar

### DIFF
--- a/pydis_site/templates/base/navbar.html
+++ b/pydis_site/templates/base/navbar.html
@@ -71,6 +71,9 @@
           <a class="navbar-item" href="{% url 'wiki:get' path="contributing/" %}">
             Contributing
           </a>
+          <a class="navbar-item" href="{% url 'timeline' %}">
+            Timeline
+          </a>
           <a class="navbar-item" href="{% url 'wiki:get' path="frequently-asked-questions/" %}">
             FAQ
           </a>


### PR DESCRIPTION
Finishes #453.

In issue #453, it was proposed that the 100k banner be removed and that the timeline was added to the navbar. Lemon removed the 100k banner, so this pr finishes the second part of that. It adds the timeline to the navbar for easy access from anywhere on the website.

Image:
![image](https://user-images.githubusercontent.com/78233879/114187272-cbf31300-9915-11eb-9d62-1bc27ff0d064.png)