### PR TITLE
Change index.html to say "100 dedicated expert helpers" instead of 90

### DIFF
--- a/pydis_site/templates/home/index.html
+++ b/pydis_site/templates/home/index.html
@@ -82,7 +82,7 @@
           </p>
           <p>
             You can find help with most Python-related problems in one of our help channels.
-            Our staff of over 90 dedicated expert Helpers are available around the clock
+            Our staff of over 100 dedicated expert Helpers are available around the clock
             in every timezone. Whether you're looking to learn the language or working on a
             complex project, we've got someone who can help you if you get stuck.
           </p>


### PR DESCRIPTION
Currently, the index.html file says that we have 90 dedicated helpers under the "Who are we?" section. This pull request changes that to 100.

This was discussed in Discord here: https://canary.discord.com/channels/267624335836053506/635950537262759947/834217942430253067