### PR TITLE
Enable permanent redirects for redirect app

### DIFF
--- a/pydis_site/apps/redirect/redirects.yaml
+++ b/pydis_site/apps/redirect/redirects.yaml
@@ -70,6 +70,12 @@ off-topic_redirect:
     redirect_route: "content:page_category"
     redirect_arguments: ["guides/pydis-guides/off-topic-etiquette"]
 
+good_questions_redirect_alt:
+    # In a few places we were linking to a version outside of the guides app.
+    original_path: pages/asking-good-questions/
+    redirect_route: "content:page_category"
+    redirect_arguments: ["guides/pydis-guides/asking-good-questions"]
+
 # Resources
 resources_index_redirect:
   original_path: pages/resources/

--- a/pydis_site/apps/redirect/tests.py
+++ b/pydis_site/apps/redirect/tests.py
@@ -56,6 +56,6 @@ class RedirectTests(TestCase):
                         f"home:{data['redirect_route']}",
                         args=expected_args
                     ),
-                    status_code=302
+                    status_code=301
                 )
                 self.assertEqual(resp.status_code, 200)

--- a/pydis_site/apps/redirect/views.py
+++ b/pydis_site/apps/redirect/views.py
@@ -6,9 +6,7 @@ from django.views.generic import RedirectView
 class CustomRedirectView(RedirectView):
     """Extended RedirectView for manual route args."""
 
-    # We want temporary redirects for the time being, after this is running on prod and
-    # stable we can enable permanent redirects.
-    permanent = False
+    permanent = True
     static_args = ()
     prefix_redirect = False
 


### PR DESCRIPTION
After monitoring traffic ingressing and confirming redirects are working as expected, I'm happy to switch redirects from the redirect app to using 301 permanent redirect.