### PR TITLE
Modify env vars list for Lancebot and Python

### DIFF
--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot.md
@@ -103,9 +103,8 @@ The following is a list of all available environment variables used by the bot:
 | -------- | -------- | -------- |
 | `BOT_TOKEN` | Always | Your Discord bot account's token (see [Test server and bot account](#test-server-and-bot-account)). |
 | `BOT_API_KEY` | When running bot without Docker | Used to authenticate with the site's API. When using Docker to run the bot, this is automatically set. By default, the site will always have the API key shown in the example below. |
-| `REDDIT_CLIENT_ID` | reddit cog | OAuth2 client ID for authenticating with the [reddit API](https://github.com/reddit-archive/reddit/wiki/OAuth2). |
-| `REDDIT_SECRET` | reddit cog | OAuth2 secret for authenticating with the reddit API. *Leave empty if you're not using the reddit API.* |
 | `BOT_SENTRY_DSN` | When connecting the bot to sentry | The DSN of the sentry monitor. |
+| `BOT_TRACE_LOGGERS ` | When you wish to see specific or all trace logs | Comma separated list that specifies which loggers emit trace logs through the listed names. If the ! prefix is used, all of the loggers except the listed ones are set to the trace level. If * is used, the root logger is set to the trace level. |
 | `REDIS_PASSWORD` | When not using FakeRedis | The password to connect to the redis database. *Leave empty if you're not using REDIS.* |
 
 ---

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/sir-lancebot/env-var-reference.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/sir-lancebot/env-var-reference.md
@@ -43,6 +43,9 @@ If you will be working with an external service, you might have to set one of th
 | `GITHUB_TOKEN` | Personal access token for GitHub, raises rate limits from 60 to 5000 requests per hour. |
 | `GIPHY_TOKEN` | Required for API access. [Docs](https://developers.giphy.com/docs/api) |
 | `OMDB_API_KEY` | Required for API access. [Docs](http://www.omdbapi.com/) |
+| `REDDIT_CLIENT_ID` | OAuth2 client ID for authenticating with the [reddit API](https://github.com/reddit-archive/reddit/wiki/OAuth2). |
+| `REDDIT_SECRET` | OAuth2 secret for authenticating with the reddit API. *Leave empty if you're not using the reddit API.* |
+| `REDDIT_WEBHOOK` | Webhook ID for Reddit channel |
 | `YOUTUBE_API_KEY` | An OAuth Key or Token are required for API access. [Docs](https://developers.google.com/youtube/v3/docs#calling-the-api) |
 | `TMDB_API_KEY` | Required for API access. [Docs](https://developers.themoviedb.org/3/getting-started/introduction) |
 | `NASA_API_KEY` | Required for API access. [Docs](https://api.nasa.gov/) |


### PR DESCRIPTION
Both Python and Sir Lancebot had slightly outdated lists for environment variables, which were updated in this PR.

### Changes

Python:
Add `BOT_TRACE_LOGGERS`
Remove `REDDIT_CLIENT_ID` and `REDDIT_SECRET`

Sir Lancebot:
Add `REDDIT_CLIENT_ID`, `REDDIT_SECRET` and `REDDIT_WEBHOOK` to the Token/APIs portion of the env var reference.

### Preview:

Python:
![image](https://user-images.githubusercontent.com/78233879/118324364-eea5b800-b4cf-11eb-8c42-542a64aa17fb.png)

Sir Lancebot: 
![image](https://user-images.githubusercontent.com/78233879/118324375-f5ccc600-b4cf-11eb-9cc8-c25fe8536b17.png)

