### PR TITLE
Fix Build & Deploy workflow shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,29 @@
 # Python Discord: Site
-[![Discord][10]][11]
+
+[![Discord][12]][13]
 [![Lint & Test][1]][2]
-[![Build & Deploy][3]][4]
-[![Coverage Status][5]][6]
+[![Build][3]][4]
+[![Deploy][5]][6]
+[![Coverage Status][7]][8]
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-This is all of the code that is responsible for maintaining [our website][7] and all of its subdomains.
+This is all of the code that is responsible for maintaining [our website][9] and all of its subdomains.
 
 The website is built on Django and should be simple to set up and get started with.
 If you happen to run into issues with setup, please don't hesitate to open an issue!
 
-If you're looking to contribute or play around with the code, take a look at [the wiki][8] or the [`docs` directory](docs). If you're looking for things to do, check out [our issues][9].
+If you're looking to contribute or play around with the code, take a look at [the wiki][10] or the [`docs` directory](docs). If you're looking for things to do, check out [our issues][11].
 
 [1]: https://github.com/python-discord/site/workflows/Lint%20&%20Test/badge.svg?branch=main
 [2]: https://github.com/python-discord/site/actions?query=workflow%3A%22Lint+%26+Test%22+branch%3Amain
-[3]: https://github.com/python-discord/site/workflows/Build%20&%20Deploy/badge.svg?branch=main
-[4]: https://github.com/python-discord/site/actions?query=workflow%3A%22Build+%26+Deploy%22+branch%3Amain
-[5]: https://coveralls.io/repos/github/python-discord/site/badge.svg?branch=main
-[6]: https://coveralls.io/github/python-discord/site?branch=main
-[7]: https://pythondiscord.com
-[8]: https://pythondiscord.com/pages/contributing/site/
-[9]: https://github.com/python-discord/site/issues
-[10]: https://raw.githubusercontent.com/python-discord/branding/main/logos/badge/badge_github.svg
-[11]: https://discord.gg/python
+[3]: https://github.com/python-discord/site/workflows/Build/badge.svg?branch=main
+[4]: https://github.com/python-discord/site/actions?query=workflow%3A%22Build%22+branch%3Amain
+[5]: https://github.com/python-discord/site/workflows/Deploy/badge.svg?branch=main
+[6]: https://github.com/python-discord/site/actions?query=workflow%3A%22Deploy%22+branch%3Amain
+[7]: https://coveralls.io/repos/github/python-discord/site/badge.svg?branch=main
+[8]: https://coveralls.io/github/python-discord/site?branch=main
+[9]: https://pythondiscord.com
+[10]: https://pythondiscord.com/pages/contributing/site/
+[11]: https://github.com/python-discord/site/issues
+[12]: https://raw.githubusercontent.com/python-discord/branding/main/logos/badge/badge_github.svg
+[13]: https://discord.gg/python


### PR DESCRIPTION
## Workflow shields
The `Build and Deploy` workflow seems to have been separated into two different workflows. IDK when.

This PR just separates the shield into 2 separate shields for each workflow, because the old README seemed to mess up because of the non-existent shield