### PR TITLE
Update guides to use `poetry` instead of `pipenv`

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -82,8 +82,8 @@ Make sure you add the following to your hosts file:
 ```
 When trying to access the site, you'll be using the domains above instead of the usual `localhost:8000`.
 
-Finally, you will need to set the environment variable `DEBUG=1`. When using `pipenv`, you can
-set put this into an `.env` file to have it exported automatically. It's also recommended to
+Finally, you will need to set the environment variable `DEBUG=1`. If you have `python-dotenv` installed, you can put this into a
+ `.env` file to have it exported automatically. It's also recommended to
 export `LOG_LEVEL=INFO` when using `DEBUG=1` if you don't want super verbose logs.
 
 To run the server, run `python manage.py runserver`. If it gives you an error saying

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/contributing-guidelines/supplemental-information.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/contributing-guidelines/supplemental-information.md
@@ -40,7 +40,7 @@ If the linter complains, the commit is aborted so that you can fix the linting e
 That way, you never commit the problematic code in the first place!
 
 Please refer to the project-specific documentation to see how to setup and run those tools.
-In most cases, you can install pre-commit using `pipenv run precommit` or `poetry run task precommit`, and lint using `pipenv run lint` or `poetry run task lint`.
+In most cases, you can install pre-commit using `poetry run task precommit`, and lint using `poetry run task lint`.
 
 ## Type Hinting
 

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/installing-project-dependencies.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/installing-project-dependencies.md
@@ -21,7 +21,7 @@ You should have already cloned your fork as described in [**Cloning a Repository
 4. Navigate to `Project Interpreter`, then click the gear icon and click `Add`.<br/>
 ![PyCharm Interpreter Settings](/static/images/content/contributing/pycharm_interpreter.png)<br/>
 5. Click `Poetry Environment`, then click `OK`.<br/>
-![PyCharm Pipenv Environment](/static/images/content/contributing/pycharm_poetry.png)<br/>
+![PyCharm Poetry Environment](/static/images/content/contributing/pycharm_poetry.png)<br/>
 6. PyCharm will automatically install the packages required into a virtual environment.<br/>
 ![PyCharm Project Interpreter](/static/images/content/contributing/pycharm_poetry_success.png)
 

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/site.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/site.md
@@ -7,9 +7,9 @@ toc: 1
 
 # Requirements
 
-- [Python 3.8](https://www.python.org/downloads/)
-- [Pipenv](https://github.com/pypa/pipenv#installation)
-    - `pip install pipenv`
+- [Python 3.9](https://www.python.org/downloads/)
+- [Poetry](https://python-poetry.org/docs/#installation)
+    - `pip install poetry`
 - [Git](https://git-scm.com/downloads)
     - [Windows](https://git-scm.com/download/win)
     - [MacOS](https://git-scm.com/download/mac) or `brew install git`
@@ -122,10 +122,10 @@ If you're not using Docker, then use [pg_ctl](https://www.postgresql.org/docs/cu
 
 ### Webserver
 
-Starting the webserver is done simply through pipenv:
+Starting the webserver is done simply through poetry:
 
 ```shell
-pipenv run start
+poetry run task start
 ```
 
 ---


### PR DESCRIPTION
We've recently changed site, bot and sir-lancebot to use `poetry` instead of `pipenv`. This PR updates the contributing guides that still mention `pipenv`.