### PR TITLE
Authenticate with the github api to avoid rate limits

### DIFF
--- a/pydis_site/apps/home/views/home.py
+++ b/pydis_site/apps/home/views/home.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from django.views import View
 
 from pydis_site.apps.home.models import RepositoryMetadata
+from pydis_site.constants import GITHUB_TOKEN
 
 log = logging.getLogger(__name__)
 
@@ -18,6 +19,7 @@ class HomeView(View):
 
     github_api = "https://api.github.com/users/python-discord/repos?per_page=100"
     repository_cache_ttl = 3600
+    headers = {"Authorization": f"token {GITHUB_TOKEN}"}
 
     # Which of our GitHub repos should be displayed on the front page, and in which order?
     repos = [
@@ -42,7 +44,7 @@ class HomeView(View):
         repo_dict = {}
 
         # Fetch the data from the GitHub API
-        api_data: List[dict] = requests.get(self.github_api).json()
+        api_data: List[dict] = requests.get(self.github_api, headers=self.headers).json()
 
         # Process the API data into our dict
         for repo in api_data:

--- a/pydis_site/constants.py
+++ b/pydis_site/constants.py
@@ -1,3 +1,4 @@
 import os
 
 GIT_SHA = os.environ.get("GIT_SHA", "development")
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")


### PR DESCRIPTION
Closes #512

Previously we weren't authenticating with the github API, which led to us hitting ratelimits on the github API.

These rate limits would raise an error when trying to re-fetch repo meta data on the homepage.