### PR TITLE
Update `IntegrityError` pattern for PostgreSQL 13.

### DIFF
--- a/pydis_site/apps/api/tests/test_infractions.py
+++ b/pydis_site/apps/api/tests/test_infractions.py
@@ -664,7 +664,10 @@ class CreationTests(APISubdomainTestCase):
         )
 
     def test_integrity_error_if_missing_active_field(self):
-        pattern = 'null value in column "active" violates not-null constraint'
+        pattern = (
+            'null value in column "active" (of relation "api_infraction" )?'
+            'violates not-null constraint'
+        )
         with self.assertRaisesRegex(IntegrityError, pattern):
             Infraction.objects.create(
                 user=self.user,


### PR DESCRIPTION
A more specific error is raised on higher PostgreSQL versions, for example, as
with the PostgreSQL version running on my local machine. This commit fixes the
error message pattern matching behaviour by adding an optional match to the
detailed error message.