### PR TITLE
Include metricity db creation for local setup guide.

### DIFF
--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/site.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/site.md
@@ -62,6 +62,7 @@ Run the following queries to create the user and database:
 ```sql
 CREATE USER pysite WITH SUPERUSER PASSWORD 'pysite';
 CREATE DATABASE pysite WITH OWNER pysite;
+CREATE DATABASE metricity WITH OWNER pysite;
 ```
 
 Finally, enter `/q` to exit psql.


### PR DESCRIPTION
This is later mentioned in the connection string, but in the local setup, the
SQL statement to create the database was missing.