### PR TITLE
Create issue template for resource suggestions.

### DIFF
--- a/.github/ISSUE_TEMPLATE/resource_suggestion.md
+++ b/.github/ISSUE_TEMPLATE/resource_suggestion.md
@@ -1,0 +1,21 @@
+---
+name: Resource Suggestion
+about: Suggest a resource for the Python Discord resource index.
+title: 'Resource Suggestion: '
+labels: 'resource suggestion'
+assignees: 'swfarnsworth'
+---
+
+**Resource name**
+
+**Resource location**\
+Should be a link of some kind, either to the resource itself or (in the case of resources that must be purchased) an information page about it.
+
+**Payment type**\
+Options are free, paid, and subscription. Combinations of these are allowed for special cases (like a limited free version).
+
+**Why it should be included**\
+A brief explanation for why you think this resource is valuable.
+
+**Potential limitations**\
+Is the resource easy to use? Does it contain good information but have poorly-written code? Is it outdated in some way? If so, explain why it should still be included.


### PR DESCRIPTION
Here's a template for incoming resource suggestions. It prompts the individual to provide some information about the resource, though the information that I think can most easily be inferred (like topic or type) or which I think should be left up to the reviewers (like difficultly level) are omitted. We might go with a different template before we start actively encouraging people outside the staff to start submitting resources.