### PR TITLE
Fix error_page stylesheet

### DIFF
--- a/pydis_site/static/css/error_pages.css
+++ b/pydis_site/static/css/error_pages.css
@@ -48,7 +48,6 @@ li {
     display: flex;
     flex-direction: column;
     max-width: 512px;
-    background-color: white;
     border-radius: 20px;
     overflow: hidden;
     box-shadow: 5px 7px 40px rgba(0, 0, 0, 0.432);
@@ -64,4 +63,5 @@ li {
 
 .content-box {
     padding: 25px;
+    background: #fff;
 }


### PR DESCRIPTION
Hi :wave:

I noticed that background color appears behind the error box in the error_page.css stylesheet in the top left and right corner

Before the change:
![screenshot](https://user-images.githubusercontent.com/73843130/122099214-469e4a00-ce01-11eb-98ad-9156c24d49c3.png)

After the change:
![screenshot](https://user-images.githubusercontent.com/73843130/122099946-1efbb180-ce02-11eb-9ff4-4bc81eb85cc1.png)

I hope that simple change helps :sweat_smile: