### PR TITLE
Add cache purge step to CI deploy stage

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -44,7 +44,7 @@ jobs:
               site/deployment.yaml
           images: 'ghcr.io/python-discord/site:${{ steps.sha_tag.outputs.tag }}'
           kubectl-version: 'latest'
-          
+
       - name: Purge Cloudflare Edge Cache
         uses: jakejarvis/cloudflare-purge-action@master
         env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -44,3 +44,9 @@ jobs:
               site/deployment.yaml
           images: 'ghcr.io/python-discord/site:${{ steps.sha_tag.outputs.tag }}'
           kubectl-version: 'latest'
+          
+      - name: Purge Cloudflare Edge Cache
+        uses: jakejarvis/cloudflare-purge-action@master
+        env:
+          CLOUDFLARE_ZONE: 989c984a358bfcd1e9b9d188cc86c1df
+          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_CACHE_TOKEN }}


### PR DESCRIPTION
I want to serve site from the edge, since the content there is primarily static. This PR ensures that cached content is cleared upon deploy so that we can benefit from high edge cache TTLs while still having new content deploy immediately.