### PR TITLE
Docker-compose: upgrade to postgres 13

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@
 version: "3.6"
 services:
   postgres:
-    image: postgres:12-alpine
+    image: postgres:13-alpine
     ports:
       - "127.0.0.1:7777:5432"
     environment:


### PR DESCRIPTION
We have been using postgres 13 in production for a long time, but we never actually updated the docker-compose environment.

A draft of the announcement can be found [here](https://discord.com/channels/267624335836053506/411200599653351425/858693693342875659). 