### PR TITLE
Add docker-compose.override.yml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,9 @@ rethinkdb_data/
 # Node modules
 node_modules/
 
+# User configuration
+docker-compose.override.yml
+
 pip-wheel-metadata/
 staticfiles/
 


### PR DESCRIPTION
The override file can be used to customize compose locally; makes the gitignore consistent with bot's which had the file added in https://github.com/python-discord/bot/pull/1584