### PR TITLE
Rename repl.it to replit and update links

### DIFF
--- a/pydis_site/apps/resources/resources/tools/ides/replit.yaml
+++ b/pydis_site/apps/resources/resources/tools/ides/replit.yaml
@@ -1,5 +1,5 @@
 description: A free, collaborative, in-browser IDE to code in 50+ languages —
   without spending a second on setup.
-name: repl.it
-title_url: https://repl.it/
+name: replit
+title_url: https://replit.com/
 position: 3


### PR DESCRIPTION
replit recently updated branding to replit.com, so we now reflect that in our site too.

Closes #554