### PR TITLE
Fixes Broken Doc Link

### DIFF
--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/sir-lancebot.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/sir-lancebot.md
@@ -97,7 +97,7 @@ The first time you run this command, it may take a few minutes while Docker down
 $ docker-compose up
 ```
 
-If you get any Docker related errors, reference the [Possible Issues](./docker/possible-issues) section of the Docker page.
+If you get any Docker related errors, reference the [Possible Issues](../docker#possible-issues) section of the Docker page.
 {: .notification .is-warning }
 
 ## Run on the host


### PR DESCRIPTION
Fixes a slightly malformed link, which is 404ing in the [sir-lance set up guide](https://pythondiscord.com/pages/guides/pydis-guides/contributing/sir-lancebot/#run-with-docker) (link in the yellow box, in the linked section).