### PR TITLE
Added list of cj8 submissions in subpage

### DIFF
--- a/pydis_site/templates/events/pages/code-jams/8/_index.html
+++ b/pydis_site/templates/events/pages/code-jams/8/_index.html
@@ -52,11 +52,10 @@
             <li>The Qualifier must be submitted through the Code Jam sign-up form.</li>
         </ul>
     </p>
-    <h3 id="how-to-join"><a href="#how-to-join">How to Join</a></h3>
+    <h3 id="submissions"><a href="#submissions">Submissions</a></h3>
     <p>
-        To enter into the code jam you must complete <a href="#qualifier">The Qualifier</a> and submit the sign-up form.
-        Don't forget to join us on Discord at <a href="https://discord.gg/python">discord.gg/python</a>!
-        <div class="has-text-centered"><a class="button is-link" href="https://form.jotform.com/211714357615050" target="_blank">Sign up for the Code Jam</a></div>
+        63 teams started out on July 9th 2021. By the end of the jam, 51 teams made project submissions. Check them all out here:
+        <div class="has-text-centered"><a class="button is-link" href="submissions">View Submissions</a></div>
     </p>
     <h3 id="prizes"><a href="#prizes">Prizes</a></h3>
     <p>

--- a/pydis_site/templates/events/pages/code-jams/8/submissions.html
+++ b/pydis_site/templates/events/pages/code-jams/8/submissions.html
@@ -21,7 +21,7 @@
             <p class="has-text-centered">Acute Alligators</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/n0remac/Acute-Alligators-2021-Summer-Code-Jam" title="Acute Alligators Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/n0remac/Acute-Alligators-2021-Summer-Code-Jam" title="Acute Alligators' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -30,7 +30,7 @@
             <p class="has-text-centered">Adaptable Antelopes</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/BoraxTheClean/adaptable-antelopes" title="Adaptable Antelopes Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/BoraxTheClean/adaptable-antelopes" title="Adaptable Antelopes' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -39,7 +39,7 @@
             <p class="has-text-centered">Astounding Arapaimas</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/p0lygun/astounding-arapaimas" title="Astounding Arapaimas Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/p0lygun/astounding-arapaimas" title="Astounding Arapaimas' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -48,7 +48,7 @@
             <p class="has-text-centered">Beatific Bulldogs</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/beatific-bulldogs/code-jam" title="Beatific Bulldogs Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/beatific-bulldogs/code-jam" title="Beatific Bulldogs' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -57,7 +57,7 @@
             <p class="has-text-centered">Benevolent Bonobos</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Anand1310/summer-code-jam-2021" title="Benevolent Bonobos Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Anand1310/summer-code-jam-2021" title="Benevolent Bonobos' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -66,7 +66,7 @@
             <p class="has-text-centered">Blessed Badgers</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/StephD/CJ8-blessed-badgers" title="Blessed Badgers Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/StephD/CJ8-blessed-badgers" title="Blessed Badgers' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -75,7 +75,7 @@
             <p class="has-text-centered">Bright Bluefins</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/DavinderJolly/bright-bluefins/" title="Bright Bluefins Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/DavinderJolly/bright-bluefins/" title="Bright Bluefins' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -84,7 +84,7 @@
             <p class="has-text-centered">Businesslike Buffalo</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Sahaj001/Businesslike_Buffalo" title="Businesslike Buffalo Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Sahaj001/Businesslike_Buffalo" title="Businesslike Buffalo's Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -93,7 +93,7 @@
             <p class="has-text-centered">Canny Capybaras</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/aiyayayaya/canny-capybaras-collab-code-contest" title="Canny Capybaras Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/aiyayayaya/canny-capybaras-collab-code-contest" title="Canny Capybaras' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -102,7 +102,7 @@
             <p class="has-text-centered">Cheerful Cheetahs</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/cj8-cheerful-cheetahs/project" title="Cheerful Cheetahs Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/cj8-cheerful-cheetahs/project" title="Cheerful Cheetahs' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -111,7 +111,7 @@
             <p class="has-text-centered">Classic Clownfish</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Istalantar/SCJ-2021-classic-clownfish" title="Classic Clownfish Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Istalantar/SCJ-2021-classic-clownfish" title="Classic Clownfish's Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -120,7 +120,7 @@
             <p class="has-text-centered">Considerate Coatis</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/yashkir/considerate-coatis" title="Considerate Coatis Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/yashkir/considerate-coatis" title="Considerate Coatis' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -129,7 +129,7 @@
             <p class="has-text-centered">Dedicated Dugongs</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Areking-RS/Code-jam-2021" title="Dedicated Dugongs Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Areking-RS/Code-jam-2021" title="Dedicated Dugongs' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -138,7 +138,7 @@
             <p class="has-text-centered">Discrete Dingos</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/somthecoder/CodeJam-Discrete-Dingos" title="Discrete Dingos Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/somthecoder/CodeJam-Discrete-Dingos" title="Discrete Dingos' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -147,7 +147,7 @@
             <p class="has-text-centered">Enlightened Elks</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/GriceTurrble/enlightened-elks-codejam/" title="Enlightened Elks Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/GriceTurrble/enlightened-elks-codejam/" title="Enlightened Elks' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -156,7 +156,7 @@
             <p class="has-text-centered">Esteemed Emus</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Vthechamp22/esteemed-emus" title="Esteemed Emus Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Vthechamp22/esteemed-emus" title="Esteemed Emus' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -165,7 +165,7 @@
             <p class="has-text-centered">Favorable Fishers</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/UntriexTv/favorable-fishers" title="Favorable Fishers Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/UntriexTv/favorable-fishers" title="Favorable Fishers' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -174,7 +174,7 @@
             <p class="has-text-centered">Feisty Ferrets</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/ToxicKidz/summer-code-jam-8" title="Feisty Ferrets Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/ToxicKidz/summer-code-jam-8" title="Feisty Ferrets' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -183,7 +183,7 @@
             <p class="has-text-centered">Gallant Grasshoppers</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/StackedQueries/gallant-grasshoppers" title="Gallant Grasshoppers Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/StackedQueries/gallant-grasshoppers" title="Gallant Grasshoppers' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -192,7 +192,7 @@
             <p class="has-text-centered">Grand Geckos</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/imsofi/codejam-grand-geckos/" title="Grand Geckos Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/imsofi/codejam-grand-geckos/" title="Grand Geckos' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -201,7 +201,7 @@
             <p class="has-text-centered">Hospitable Hares</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/samarthkulshrestha/hospitable-hares_code-jam-8" title="Hospitable Hares Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/samarthkulshrestha/hospitable-hares_code-jam-8" title="Hospitable Hares' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -210,7 +210,7 @@
             <p class="has-text-centered">Humorous Honeybees</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/mirandazellnik/code-jam-2021" title="Humorous Honeybees Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/mirandazellnik/code-jam-2021" title="Humorous Honeybees' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -219,7 +219,7 @@
             <p class="has-text-centered">Jaunty Jackals</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Jaunty-Jackals/jaunty-jackals" title="Jaunty Jackals Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Jaunty-Jackals/jaunty-jackals" title="Jaunty Jackals' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -228,7 +228,7 @@
             <p class="has-text-centered">Jazzed Jerboas</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/tomheaton/pcj8-jazzed-jerboas" title="Jazzed Jerboas Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/tomheaton/pcj8-jazzed-jerboas" title="Jazzed Jerboas' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -237,7 +237,7 @@
             <p class="has-text-centered">Jubilant Jellyfish</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Cheepsss/Jubilant-Jellyfish" title="Jubilant Jellyfish Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Cheepsss/Jubilant-Jellyfish" title="Jubilant Jellyfish's Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -246,7 +246,7 @@
             <p class="has-text-centered">Lovable Lobsters</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/A5rocks/code-jam-8" title="Lovable Lobsters Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/A5rocks/code-jam-8" title="Lovable Lobsters' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -255,7 +255,7 @@
             <p class="has-text-centered">Magical Muskrats</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/harjyotbagga/escape-room" title="Magical Muskrats Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/harjyotbagga/escape-room" title="Magical Muskrats' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -264,7 +264,7 @@
             <p class="has-text-centered">Mature Magpies</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Mature-Magpies/think-inside-the-box" title="Mature Magpies Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Mature-Magpies/think-inside-the-box" title="Mature Magpies' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -273,7 +273,7 @@
             <p class="has-text-centered">Merciful Millipedes</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Reuben27/Merciful-Millipedes" title="Merciful Millipedes Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Reuben27/Merciful-Millipedes" title="Merciful Millipedes' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -282,7 +282,7 @@
             <p class="has-text-centered">Meteoric Minks</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/meteoric-minks/code-jam" title="Meteoric Minks Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/meteoric-minks/code-jam" title="Meteoric Minks' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -291,7 +291,7 @@
             <p class="has-text-centered">Modern Meerkats</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Ahmed-Khaled-dev/modern-meerkats" title="Modern Meerkats Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Ahmed-Khaled-dev/modern-meerkats" title="Modern Meerkats' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -300,7 +300,7 @@
             <p class="has-text-centered">Notable Newts</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/meysam81/notable-newts" title="Notable Newts Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/meysam81/notable-newts" title="Notable Newts' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -309,7 +309,7 @@
             <p class="has-text-centered">Notorious Narwhals</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/smileyface12349/notorious-narwhals" title="Notorious Narwhals Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/smileyface12349/notorious-narwhals" title="Notorious Narwhals' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -318,7 +318,7 @@
             <p class="has-text-centered">Patient Panthers</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Willd14469/cj8-patient-panthers" title="Patient Panthers Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Willd14469/cj8-patient-panthers" title="Patient Panthers' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -327,7 +327,7 @@
             <p class="has-text-centered">Perceptive Porcupines</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/what-the-python/wtpython" title="Perceptive Porcupines Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/what-the-python/wtpython" title="Perceptive Porcupines' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -336,7 +336,7 @@
             <p class="has-text-centered">Poetic Pumas</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/roogla/poetic_pumas" title="Poetic Pumas Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/roogla/poetic_pumas" title="Poetic Pumas' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -345,7 +345,7 @@
             <p class="has-text-centered">Purposeful Pangolins</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/doodletaco/dataset-viewer" title="Purposeful Pangolins Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/doodletaco/dataset-viewer" title="Purposeful Pangolins' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -354,7 +354,7 @@
             <p class="has-text-centered">Quirky Quokkas</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/joshuacc1/Music-Player-CLI-Anywhere" title="Quirky Quokkas Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/joshuacc1/Music-Player-CLI-Anywhere" title="Quirky Quokkas' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -363,7 +363,7 @@
             <p class="has-text-centered">Respectful Racoons</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/manjunaath5583/respectful_racoons" title="Respectful Racoons Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/manjunaath5583/respectful_racoons" title="Respectful Racoons' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -372,7 +372,7 @@
             <p class="has-text-centered">Rhapsodic Rabbits</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/yummyyummybaguette/rhapsodic-rabbits" title="Rhapsodic Rabbits Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/yummyyummybaguette/rhapsodic-rabbits" title="Rhapsodic Rabbits' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -381,7 +381,7 @@
             <p class="has-text-centered">Robust Reindeer</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/bjoseru/pdcj8-robust-reindeer" title="Robust Reindeer Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/bjoseru/pdcj8-robust-reindeer" title="Robust Reindeer's Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -390,7 +390,7 @@
             <p class="has-text-centered">Scholarly Skunks</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Davidy22/scholarlySkunkJam/" title="Scholarly Skunks Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Davidy22/scholarlySkunkJam/" title="Scholarly Skunks' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -399,7 +399,7 @@
             <p class="has-text-centered">Secretive Squirrels</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/dain-xyz/python-jam-2021-2" title="Secretive Squirrels Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/dain-xyz/python-jam-2021-2" title="Secretive Squirrels' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -408,7 +408,7 @@
             <p class="has-text-centered">Sleek Snails</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Sleek-Snails/Snail-Snacks" title="Sleek Snails Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Sleek-Snails/Snail-Snacks" title="Sleek Snails' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -417,7 +417,7 @@
             <p class="has-text-centered">Spellbinding Squids</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/SystematicError/code-jam" title="Spellbinding Squids Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/SystematicError/code-jam" title="Spellbinding Squids' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -426,7 +426,7 @@
             <p class="has-text-centered">Stylish Salamanders</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Darklight-user/code-jam-stylish-salamanders" title="Stylish Salamanders Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Darklight-user/code-jam-stylish-salamanders" title="Stylish Salamanders' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -435,7 +435,7 @@
             <p class="has-text-centered">Tactful Tunas</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Yagueteiro/code-jam-2021/" title="Tactful Tunas Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Yagueteiro/code-jam-2021/" title="Tactful Tunas' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -444,7 +444,7 @@
             <p class="has-text-centered">Transcendent Tarsiers</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/kronifer/cj8-repo" title="Transcendent Tarsiers Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/kronifer/cj8-repo" title="Transcendent Tarsiers' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -453,7 +453,7 @@
             <p class="has-text-centered">Tubular Terriers</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Tubular-Terriers/code-jam" title="Tubular Terriers Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Tubular-Terriers/code-jam" title="Tubular Terriers' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -462,7 +462,7 @@
             <p class="has-text-centered">Virtuous Vultures</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/iceCream-Taco/cj8-virtuous-vultures" title="Virtuous Vultures Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/iceCream-Taco/cj8-virtuous-vultures" title="Virtuous Vultures' Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -471,7 +471,7 @@
             <p class="has-text-centered">Whimsical Woolly Mammoths</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/SilverSlashDiscord/whimsical-woolly-mammoths" title="Whimsical Woolly Mammoths Repository">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/SilverSlashDiscord/whimsical-woolly-mammoths" title="Whimsical Woolly Mammoths' Repository">GitHub</a></p>
         </div>
     </div>
 

--- a/pydis_site/templates/events/pages/code-jams/8/submissions.html
+++ b/pydis_site/templates/events/pages/code-jams/8/submissions.html
@@ -1,0 +1,484 @@
+{% extends "events/base_sidebar.html" %}
+
+{% load static %}
+
+{% block title %}Summer Code Jam 2021{% endblock %}
+
+{% block breadcrumb %}
+    <li><a href="{% url "events:index" %}">Events</a></li>
+    <li><a href="{% url "events:page" path="code-jams" %}">Code Jams</a></li>
+    <li><a href="{% url "events:page" path="code-jams/8" %}">Summer Code Jam 2021</a></li>
+    <li class="is-active"><a href="#">Submissions</a></li>
+{% endblock %}
+
+{% block event_content %}
+    <p>
+        Below is a list of all projects submitted by the end of Summer Code Jam 2021
+    </p>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Acute Alligators</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/n0remac/Acute-Alligators-2021-Summer-Code-Jam">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Adaptable Antelopes</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/BoraxTheClean/adaptable-antelopes">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Astounding Arapaimas</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/p0lygun/astounding-arapaimas">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Beatific Bulldogs</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/beatific-bulldogs/code-jam">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Benevolent Bonobos</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/Anand1310/summer-code-jam-2021">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Blessed Badgers</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/StephD/CJ8-blessed-badgers">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Bright Bluefins</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/DavinderJolly/bright-bluefins/">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Businesslike Buffalo</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/Sahaj001/Businesslike_Buffalo">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Canny Capybaras</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/aiyayayaya/canny-capybaras-collab-code-contest">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Cheerful Cheetahs</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/cj8-cheerful-cheetahs/project">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Classic Clownfish</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/Istalantar/SCJ-2021-classic-clownfish">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Considerate Coatis</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/yashkir/considerate-coatis">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Dedicated Dugongs</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/Areking-RS/Code-jam-2021">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Discrete Dingos</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/somthecoder/CodeJam-Discrete-Dingos">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Enlightened Elks</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/GriceTurrble/enlightened-elks-codejam/">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Esteemed Emus</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/Vthechamp22/esteemed-emus">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Favorable Fishers</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/UntriexTv/favorable-fishers">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Feisty Ferrets</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/ToxicKidz/summer-code-jam-8">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Gallant Grasshoppers</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/StackedQueries/gallant-grasshoppers">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Grand Geckos</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/imsofi/codejam-grand-geckos/">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Hospitable Hares</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/samarthkulshrestha/hospitable-hares_code-jam-8">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Humorous Honeybees</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/mirandazellnik/code-jam-2021">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Jaunty Jackals</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/Jaunty-Jackals/jaunty-jackals">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Jazzed Jerboas</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/tomheaton/pcj8-jazzed-jerboas">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Jubilant Jellyfish</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/Cheepsss/Jubilant-Jellyfish">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Lovable Lobsters</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/A5rocks/code-jam-8">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Magical Muskrats</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/harjyotbagga/escape-room">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Mature Magpies</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/Mature-Magpies/think-inside-the-box">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Merciful Millipedes</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/Reuben27/Merciful-Millipedes">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Meteoric Minks</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/meteoric-minks/code-jam">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Modern Meerkats</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/Ahmed-Khaled-dev/modern-meerkats">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Notable Newts</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/meysam81/notable-newts">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Notorious Narwhals</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/smileyface12349/notorious-narwhals">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Patient Panthers</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/Willd14469/cj8-patient-panthers">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Perceptive Porcupines</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/what-the-python/wtpython">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Poetic Pumas</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/roogla/poetic_pumas">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Purposeful Pangolins</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/doodletaco/dataset-viewer">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Quirky Quokkas</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/joshuacc1/Music-Player-CLI-Anywhere">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Respectful Racoons</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/manjunaath5583/respectful_racoons">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Rhapsodic Rabbits</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/yummyyummybaguette/rhapsodic-rabbits">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Robust Reindeer</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/bjoseru/pdcj8-robust-reindeer">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Scholarly Skunks</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/Davidy22/scholarlySkunkJam/">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Secretive Squirrels</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/dain-xyz/python-jam-2021-2">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Sleek Snails</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/Sleek-Snails/Snail-Snacks">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Spellbinding Squids</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/SystematicError/code-jam">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Stylish Salamanders</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/Darklight-user/code-jam-stylish-salamanders">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Tactful Tunas</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/Yagueteiro/code-jam-2021/">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Transcendent Tarsiers</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/kronifer/cj8-repo">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Tubular Terriers</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/Tubular-Terriers/code-jam">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Virtuous Vultures</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/iceCream-Taco/cj8-virtuous-vultures">GitHub</a></p>
+        </div>
+    </div>
+
+    <div class="columns is-mobile is-centered">
+        <div class="column is-half">
+            <p class="has-text-centered">Whimsical Woolly Mammoths</p>
+        </div>
+        <div class="column is-half">
+            <p class="has-text-centered"><a href="https://github.com/SilverSlashDiscord/whimsical-woolly-mammoths">GitHub</a></p>
+        </div>
+    </div>
+
+{% endblock %}
+
+{% block sidebar %}
+
+    {% include "events/sidebar/code-jams/8.html" %}
+
+{% endblock %}

--- a/pydis_site/templates/events/pages/code-jams/8/submissions.html
+++ b/pydis_site/templates/events/pages/code-jams/8/submissions.html
@@ -21,7 +21,7 @@
             <p class="has-text-centered">Acute Alligators</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/n0remac/Acute-Alligators-2021-Summer-Code-Jam">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/n0remac/Acute-Alligators-2021-Summer-Code-Jam" title="Acute Alligators Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -30,7 +30,7 @@
             <p class="has-text-centered">Adaptable Antelopes</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/BoraxTheClean/adaptable-antelopes">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/BoraxTheClean/adaptable-antelopes" title="Adaptable Antelopes Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -39,7 +39,7 @@
             <p class="has-text-centered">Astounding Arapaimas</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/p0lygun/astounding-arapaimas">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/p0lygun/astounding-arapaimas" title="Astounding Arapaimas Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -48,7 +48,7 @@
             <p class="has-text-centered">Beatific Bulldogs</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/beatific-bulldogs/code-jam">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/beatific-bulldogs/code-jam" title="Beatific Bulldogs Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -57,7 +57,7 @@
             <p class="has-text-centered">Benevolent Bonobos</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Anand1310/summer-code-jam-2021">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Anand1310/summer-code-jam-2021" title="Benevolent Bonobos Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -66,7 +66,7 @@
             <p class="has-text-centered">Blessed Badgers</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/StephD/CJ8-blessed-badgers">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/StephD/CJ8-blessed-badgers" title="Blessed Badgers Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -75,7 +75,7 @@
             <p class="has-text-centered">Bright Bluefins</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/DavinderJolly/bright-bluefins/">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/DavinderJolly/bright-bluefins/" title="Bright Bluefins Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -84,7 +84,7 @@
             <p class="has-text-centered">Businesslike Buffalo</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Sahaj001/Businesslike_Buffalo">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Sahaj001/Businesslike_Buffalo" title="Businesslike Buffalo Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -93,7 +93,7 @@
             <p class="has-text-centered">Canny Capybaras</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/aiyayayaya/canny-capybaras-collab-code-contest">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/aiyayayaya/canny-capybaras-collab-code-contest" title="Canny Capybaras Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -102,7 +102,7 @@
             <p class="has-text-centered">Cheerful Cheetahs</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/cj8-cheerful-cheetahs/project">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/cj8-cheerful-cheetahs/project" title="Cheerful Cheetahs Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -111,7 +111,7 @@
             <p class="has-text-centered">Classic Clownfish</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Istalantar/SCJ-2021-classic-clownfish">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Istalantar/SCJ-2021-classic-clownfish" title="Classic Clownfish Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -120,7 +120,7 @@
             <p class="has-text-centered">Considerate Coatis</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/yashkir/considerate-coatis">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/yashkir/considerate-coatis" title="Considerate Coatis Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -129,7 +129,7 @@
             <p class="has-text-centered">Dedicated Dugongs</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Areking-RS/Code-jam-2021">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Areking-RS/Code-jam-2021" title="Dedicated Dugongs Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -138,7 +138,7 @@
             <p class="has-text-centered">Discrete Dingos</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/somthecoder/CodeJam-Discrete-Dingos">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/somthecoder/CodeJam-Discrete-Dingos" title="Discrete Dingos Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -147,7 +147,7 @@
             <p class="has-text-centered">Enlightened Elks</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/GriceTurrble/enlightened-elks-codejam/">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/GriceTurrble/enlightened-elks-codejam/" title="Enlightened Elks Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -156,7 +156,7 @@
             <p class="has-text-centered">Esteemed Emus</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Vthechamp22/esteemed-emus">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Vthechamp22/esteemed-emus" title="Esteemed Emus Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -165,7 +165,7 @@
             <p class="has-text-centered">Favorable Fishers</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/UntriexTv/favorable-fishers">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/UntriexTv/favorable-fishers" title="Favorable Fishers Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -174,7 +174,7 @@
             <p class="has-text-centered">Feisty Ferrets</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/ToxicKidz/summer-code-jam-8">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/ToxicKidz/summer-code-jam-8" title="Feisty Ferrets Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -183,7 +183,7 @@
             <p class="has-text-centered">Gallant Grasshoppers</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/StackedQueries/gallant-grasshoppers">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/StackedQueries/gallant-grasshoppers" title="Gallant Grasshoppers Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -192,7 +192,7 @@
             <p class="has-text-centered">Grand Geckos</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/imsofi/codejam-grand-geckos/">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/imsofi/codejam-grand-geckos/" title="Grand Geckos Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -201,7 +201,7 @@
             <p class="has-text-centered">Hospitable Hares</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/samarthkulshrestha/hospitable-hares_code-jam-8">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/samarthkulshrestha/hospitable-hares_code-jam-8" title="Hospitable Hares Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -210,7 +210,7 @@
             <p class="has-text-centered">Humorous Honeybees</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/mirandazellnik/code-jam-2021">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/mirandazellnik/code-jam-2021" title="Humorous Honeybees Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -219,7 +219,7 @@
             <p class="has-text-centered">Jaunty Jackals</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Jaunty-Jackals/jaunty-jackals">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Jaunty-Jackals/jaunty-jackals" title="Jaunty Jackals Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -228,7 +228,7 @@
             <p class="has-text-centered">Jazzed Jerboas</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/tomheaton/pcj8-jazzed-jerboas">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/tomheaton/pcj8-jazzed-jerboas" title="Jazzed Jerboas Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -237,7 +237,7 @@
             <p class="has-text-centered">Jubilant Jellyfish</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Cheepsss/Jubilant-Jellyfish">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Cheepsss/Jubilant-Jellyfish" title="Jubilant Jellyfish Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -246,7 +246,7 @@
             <p class="has-text-centered">Lovable Lobsters</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/A5rocks/code-jam-8">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/A5rocks/code-jam-8" title="Lovable Lobsters Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -255,7 +255,7 @@
             <p class="has-text-centered">Magical Muskrats</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/harjyotbagga/escape-room">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/harjyotbagga/escape-room" title="Magical Muskrats Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -264,7 +264,7 @@
             <p class="has-text-centered">Mature Magpies</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Mature-Magpies/think-inside-the-box">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Mature-Magpies/think-inside-the-box" title="Mature Magpies Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -273,7 +273,7 @@
             <p class="has-text-centered">Merciful Millipedes</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Reuben27/Merciful-Millipedes">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Reuben27/Merciful-Millipedes" title="Merciful Millipedes Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -282,7 +282,7 @@
             <p class="has-text-centered">Meteoric Minks</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/meteoric-minks/code-jam">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/meteoric-minks/code-jam" title="Meteoric Minks Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -291,7 +291,7 @@
             <p class="has-text-centered">Modern Meerkats</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Ahmed-Khaled-dev/modern-meerkats">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Ahmed-Khaled-dev/modern-meerkats" title="Modern Meerkats Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -300,7 +300,7 @@
             <p class="has-text-centered">Notable Newts</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/meysam81/notable-newts">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/meysam81/notable-newts" title="Notable Newts Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -309,7 +309,7 @@
             <p class="has-text-centered">Notorious Narwhals</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/smileyface12349/notorious-narwhals">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/smileyface12349/notorious-narwhals" title="Notorious Narwhals Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -318,7 +318,7 @@
             <p class="has-text-centered">Patient Panthers</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Willd14469/cj8-patient-panthers">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Willd14469/cj8-patient-panthers" title="Patient Panthers Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -327,7 +327,7 @@
             <p class="has-text-centered">Perceptive Porcupines</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/what-the-python/wtpython">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/what-the-python/wtpython" title="Perceptive Porcupines Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -336,7 +336,7 @@
             <p class="has-text-centered">Poetic Pumas</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/roogla/poetic_pumas">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/roogla/poetic_pumas" title="Poetic Pumas Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -345,7 +345,7 @@
             <p class="has-text-centered">Purposeful Pangolins</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/doodletaco/dataset-viewer">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/doodletaco/dataset-viewer" title="Purposeful Pangolins Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -354,7 +354,7 @@
             <p class="has-text-centered">Quirky Quokkas</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/joshuacc1/Music-Player-CLI-Anywhere">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/joshuacc1/Music-Player-CLI-Anywhere" title="Quirky Quokkas Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -363,7 +363,7 @@
             <p class="has-text-centered">Respectful Racoons</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/manjunaath5583/respectful_racoons">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/manjunaath5583/respectful_racoons" title="Respectful Racoons Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -372,7 +372,7 @@
             <p class="has-text-centered">Rhapsodic Rabbits</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/yummyyummybaguette/rhapsodic-rabbits">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/yummyyummybaguette/rhapsodic-rabbits" title="Rhapsodic Rabbits Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -381,7 +381,7 @@
             <p class="has-text-centered">Robust Reindeer</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/bjoseru/pdcj8-robust-reindeer">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/bjoseru/pdcj8-robust-reindeer" title="Robust Reindeer Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -390,7 +390,7 @@
             <p class="has-text-centered">Scholarly Skunks</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Davidy22/scholarlySkunkJam/">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Davidy22/scholarlySkunkJam/" title="Scholarly Skunks Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -399,7 +399,7 @@
             <p class="has-text-centered">Secretive Squirrels</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/dain-xyz/python-jam-2021-2">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/dain-xyz/python-jam-2021-2" title="Secretive Squirrels Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -408,7 +408,7 @@
             <p class="has-text-centered">Sleek Snails</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Sleek-Snails/Snail-Snacks">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Sleek-Snails/Snail-Snacks" title="Sleek Snails Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -417,7 +417,7 @@
             <p class="has-text-centered">Spellbinding Squids</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/SystematicError/code-jam">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/SystematicError/code-jam" title="Spellbinding Squids Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -426,7 +426,7 @@
             <p class="has-text-centered">Stylish Salamanders</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Darklight-user/code-jam-stylish-salamanders">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Darklight-user/code-jam-stylish-salamanders" title="Stylish Salamanders Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -435,7 +435,7 @@
             <p class="has-text-centered">Tactful Tunas</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Yagueteiro/code-jam-2021/">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Yagueteiro/code-jam-2021/" title="Tactful Tunas Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -444,7 +444,7 @@
             <p class="has-text-centered">Transcendent Tarsiers</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/kronifer/cj8-repo">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/kronifer/cj8-repo" title="Transcendent Tarsiers Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -453,7 +453,7 @@
             <p class="has-text-centered">Tubular Terriers</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/Tubular-Terriers/code-jam">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/Tubular-Terriers/code-jam" title="Tubular Terriers Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -462,7 +462,7 @@
             <p class="has-text-centered">Virtuous Vultures</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/iceCream-Taco/cj8-virtuous-vultures">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/iceCream-Taco/cj8-virtuous-vultures" title="Virtuous Vultures Repository">GitHub</a></p>
         </div>
     </div>
 
@@ -471,7 +471,7 @@
             <p class="has-text-centered">Whimsical Woolly Mammoths</p>
         </div>
         <div class="column is-half">
-            <p class="has-text-centered"><a href="https://github.com/SilverSlashDiscord/whimsical-woolly-mammoths">GitHub</a></p>
+            <p class="has-text-centered"><a href="https://github.com/SilverSlashDiscord/whimsical-woolly-mammoths" title="Whimsical Woolly Mammoths Repository">GitHub</a></p>
         </div>
     </div>
 

--- a/pydis_site/templates/events/sidebar/code-jams/8.html
+++ b/pydis_site/templates/events/sidebar/code-jams/8.html
@@ -4,6 +4,7 @@
         <a class="panel-block has-text-link" href="{% url "events:page" path="code-jams/8/rules" %}">Rules</a>
         <a class="panel-block has-text-link" href="{% url "events:page" path="code-jams/8/frameworks" %}">Approved Frameworks</a>
         <a class="panel-block has-text-link" href="{% url "events:page" path="code-jams/8/github-bootcamp" %}">GitHub Bootcamp</a>
+        <a class="panel-block has-text-link" href="{% url "events:page" path="code-jams/8/submissions" %}">Submissions</a>
         <a class="panel-block has-text-link" href="{% url "events:page" path="code-jams/code-style-guide" %}">The Code Style Guide</a>
     </ul>
 </div>


### PR DESCRIPTION
* New page at /events/code-jams/8/submissions/ with a link to all CJ8 submissions.
* Removed the "how to join" section in the main event page, and replaced with a link to the submissions page.
* Added submissions page at sidebar.

![image](https://user-images.githubusercontent.com/18114431/127751199-58bd97c8-8e4c-4ba0-b557-2bd626b95aa9.png)
