### PR TITLE
Fix data reviews URL

### DIFF
--- a/pydis_site/templates/home/timeline.html
+++ b/pydis_site/templates/home/timeline.html
@@ -111,7 +111,7 @@
             pretty much as soon as our new bot and site starts collecting some data. To this day, we keep <a
                 href="https://pythondiscord.com/pages/privacy/">our privacy policy</a> up to date with all
             changes, and since April 2020 we've started doing <a
-                href="https://www.notion.so/6784e3a9752444e89d19e65fd4510d8d?v=69268794b9d2454a9c28e1550e2923c2">monthly data reviews</a>.</p>
+                href="https://pythondiscord.notion.site/6784e3a9752444e89d19e65fd4510d8d">monthly data reviews</a>.</p>
 
           <div class="flex justify-between items-center">
             <span class="cd-timeline__date">May 21st, 2018</span>

--- a/pydis_site/templates/home/timeline.html
+++ b/pydis_site/templates/home/timeline.html
@@ -111,7 +111,7 @@
             pretty much as soon as our new bot and site starts collecting some data. To this day, we keep <a
                 href="https://pythondiscord.com/pages/privacy/">our privacy policy</a> up to date with all
             changes, and since April 2020 we've started doing <a
-                href="https://pythondiscord.com/pages/data-reviews/">monthly data reviews</a>.</p>
+                href="https://www.notion.so/6784e3a9752444e89d19e65fd4510d8d?v=69268794b9d2454a9c28e1550e2923c2">monthly data reviews</a>.</p>
 
           <div class="flex justify-between items-center">
             <span class="cd-timeline__date">May 21st, 2018</span>


### PR DESCRIPTION
I updated the URL on the timeline for data reviews from `https://pythondiscord.com/pages/data-reviews/` to `https://www.notion.so/6784e3a9752444e89d19e65fd4510d8d?v=69268794b9d2454a9c28e1550e2923c2`.