### PR TITLE
Run collectstatic in the Docker build process and disable in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN \
     SECRET_KEY=dummy_value \
     DATABASE_URL=postgres://localhost \
     METRICITY_DB_URL=postgres://localhost \
-    python manage.py collectstatic
+    python manage.py collectstatic --noinput --clear
 
 # Run web server through custom manager
 ENTRYPOINT ["python", "manage.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,13 @@ ENV GIT_SHA=$git_sha
 # Copy the source code in last to optimize rebuilding the image
 COPY . .
 
+# Set dummy variables so collectstatic can load settings.py
+RUN \
+    SECRET_KEY=dummy_value \
+    DATABASE_URL=postgres://localhost \
+    METRICITY_DB_URL=postgres://localhost \
+    python manage.py collectstatic
+
 # Run web server through custom manager
 ENTRYPOINT ["python", "manage.py"]
 CMD ["run"]

--- a/manage.py
+++ b/manage.py
@@ -142,7 +142,7 @@ class SiteManager:
         if self.debug:
             # In Production, collectstatic is ran in the Docker image
             print("Collecting static files.")
-            call_command("collectstatic", interactive=False, clear=True, verbosity=self.verbosity)
+            call_command("collectstatic", interactive=False, clear=True, verbosity=self.verbosity - 1)
 
             self.set_dev_site_name()
             self.create_superuser()

--- a/manage.py
+++ b/manage.py
@@ -138,10 +138,12 @@ class SiteManager:
 
         print("Applying migrations.")
         call_command("migrate", verbosity=self.verbosity)
-        print("Collecting static files.")
-        call_command("collectstatic", interactive=False, clear=True, verbosity=self.verbosity)
 
         if self.debug:
+            # In Production, collectstatic is ran in the Docker image
+            print("Collecting static files.")
+            call_command("collectstatic", interactive=False, clear=True, verbosity=self.verbosity)
+
             self.set_dev_site_name()
             self.create_superuser()
 

--- a/manage.py
+++ b/manage.py
@@ -142,7 +142,12 @@ class SiteManager:
         if self.debug:
             # In Production, collectstatic is ran in the Docker image
             print("Collecting static files.")
-            call_command("collectstatic", interactive=False, clear=True, verbosity=self.verbosity - 1)
+            call_command(
+                "collectstatic",
+                interactive=False,
+                clear=True,
+                verbosity=self.verbosity - 1
+            )
 
             self.set_dev_site_name()
             self.create_superuser()


### PR DESCRIPTION
Don't run collectstatic on container start, run it in the build process!

This bakes all our static files into the Docker image meaning that we don't have to perform writes to site-packages on startup allowing us to remove some volumes from python-discord/kubernetes#92 and have a slightly faster application start up time.