### PR TITLE
[BUG FIX] - README.md - Remove the docs dir from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is all of the code that is responsible for maintaining [our website][9] and
 The website is built on Django and should be simple to set up and get started with.
 If you happen to run into issues with setup, please don't hesitate to open an issue!
 
-If you're looking to contribute or play around with the code, take a look at [the wiki][10] or the [`docs` directory](docs). If you're looking for things to do, check out [our issues][11].
+If you're looking to contribute or play around with the code, take a look at [the wiki][10]. If you're looking for things to do, check out [our issues][11].
 
 [1]: https://github.com/python-discord/site/workflows/Lint%20&%20Test/badge.svg?branch=main
 [2]: https://github.com/python-discord/site/actions?query=workflow%3A%22Lint+%26+Test%22+branch%3Amain


### PR DESCRIPTION
The README.md file had an outdated hyperlink which pointed to the docs directory which doesnt exist anymore
This PR fixes that

Commits : 1