### PR TITLE
Create a signal to unassign roles from user when the role is deleted

### DIFF
--- a/pydis_site/apps/api/__init__.py
+++ b/pydis_site/apps/api/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'pydis_site.apps.api.apps.ApiConfig'

--- a/pydis_site/apps/api/apps.py
+++ b/pydis_site/apps/api/apps.py
@@ -4,4 +4,12 @@ from django.apps import AppConfig
 class ApiConfig(AppConfig):
     """Django AppConfig for the API app."""
 
-    name = 'api'
+    name = 'pydis_site.apps.api'
+
+    def ready(self) -> None:
+        """
+        Gets called as soon as the registry is fully populated.
+
+        https://docs.djangoproject.com/en/3.2/ref/applications/#django.apps.AppConfig.ready
+        """
+        import pydis_site.apps.api.signals  # noqa: F401

--- a/pydis_site/apps/api/signals.py
+++ b/pydis_site/apps/api/signals.py
@@ -1,0 +1,12 @@
+from django.db.models.signals import pre_delete
+from django.dispatch import receiver
+
+from pydis_site.apps.api.models.bot import Role, User
+
+
+@receiver(signal=pre_delete, sender=Role)
+def delete_role_from_user(sender: Role, instance: Role, **kwargs) -> None:
+    """Unassigns the Role (instance) that is being deleted from every user that has it."""
+    for user in User.objects.filter(roles__contains=[instance.id]):
+        del user.roles[user.roles.index(instance.id)]
+        user.save()

--- a/pydis_site/apps/api/signals.py
+++ b/pydis_site/apps/api/signals.py
@@ -1,10 +1,10 @@
-from django.db.models.signals import pre_delete
+from django.db.models.signals import post_delete
 from django.dispatch import receiver
 
 from pydis_site.apps.api.models.bot import Role, User
 
 
-@receiver(signal=pre_delete, sender=Role)
+@receiver(signal=post_delete, sender=Role)
 def delete_role_from_user(sender: Role, instance: Role, **kwargs) -> None:
     """Unassigns the Role (instance) that is being deleted from every user that has it."""
     for user in User.objects.filter(roles__contains=[instance.id]):

--- a/pydis_site/apps/api/tests/test_roles.py
+++ b/pydis_site/apps/api/tests/test_roles.py
@@ -199,6 +199,7 @@ class CreationTests(AuthenticatedAPITestCase):
     def test_role_delete_unassigned(self):
         """Tests if the deleted Role gets unassigned from the user."""
         self.role_to_delete.delete()
+        self.role_unassigned_test_user.refresh_from_db()
         self.assertEqual(self.role_unassigned_test_user.roles, [])
 
     def test_role_detail_404_all_methods(self):

--- a/pydis_site/apps/api/tests/test_roles.py
+++ b/pydis_site/apps/api/tests/test_roles.py
@@ -1,7 +1,8 @@
 from django.urls import reverse
 
 from .base import AuthenticatedAPITestCase
-from ..models import Role
+from ..models import Role, User
+
 
 
 class CreationTests(AuthenticatedAPITestCase):
@@ -34,6 +35,20 @@ class CreationTests(AuthenticatedAPITestCase):
             colour=6,
             permissions=6,
             position=0,
+        )
+        cls.role_to_delete = Role.objects.create(
+            id=7,
+            name="role to delete",
+            colour=7,
+            permissions=7,
+            position=0,
+        )
+        cls.role_unassigned_test_user = User.objects.create(
+            id=8,
+            name="role_unassigned_test_user",
+            discriminator="0000",
+            roles=[cls.role_to_delete.id],
+            in_guild=True
         )
 
     def _validate_roledict(self, role_dict: dict) -> None:
@@ -180,6 +195,11 @@ class CreationTests(AuthenticatedAPITestCase):
         url = reverse('api:bot:role-detail', args=(self.admins_role.id,))
         response = self.client.delete(url)
         self.assertEqual(response.status_code, 204)
+
+    def test_role_delete_unassigned(self):
+        """Tests if the deleted Role gets unassigned from the user."""
+        self.role_to_delete.delete()
+        self.assertEqual(self.role_unassigned_test_user.roles, [])
 
     def test_role_detail_404_all_methods(self):
         """Tests detail view with non-existing ID."""

--- a/pydis_site/apps/api/tests/test_roles.py
+++ b/pydis_site/apps/api/tests/test_roles.py
@@ -4,7 +4,6 @@ from .base import AuthenticatedAPITestCase
 from ..models import Role, User
 
 
-
 class CreationTests(AuthenticatedAPITestCase):
     @classmethod
     def setUpTestData(cls):
@@ -96,11 +95,11 @@ class CreationTests(AuthenticatedAPITestCase):
         url = reverse('api:bot:role-list')
 
         response = self.client.get(url)
-        self.assertContains(response, text="id", count=4, status_code=200)
+        self.assertContains(response, text="id", count=5, status_code=200)
 
         roles = response.json()
         self.assertIsInstance(roles, list)
-        self.assertEqual(len(roles), 4)
+        self.assertEqual(len(roles), 5)
 
         for role in roles:
             self._validate_roledict(role)


### PR DESCRIPTION
Add a signal to the api app that automatically unassigns
deleted roles from users that have them
Closes #369