### PR TITLE
Timeout when fetching GitHub repository metadata

### DIFF
--- a/pydis_site/constants.py
+++ b/pydis_site/constants.py
@@ -2,3 +2,5 @@ import os
 
 GIT_SHA = os.environ.get("GIT_SHA", "development")
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
+# How long to wait for synchronous requests before timing out
+TIMEOUT_PERIOD = int(os.environ.get("TIMEOUT_PERIOD", 5))


### PR DESCRIPTION
Closes #576 

Not having this timeout could cause a worker to hang indefinitely.