### PR TITLE
Add pod IPs to allowed hosts

### DIFF
--- a/pydis_site/settings.py
+++ b/pydis_site/settings.py
@@ -14,6 +14,7 @@ import os
 import secrets
 import sys
 from pathlib import Path
+from socket import gethostname, gethostbyname
 
 import environ
 import sentry_sdk
@@ -59,6 +60,8 @@ else:
             'api.pythondiscord.com',
             'staff.pythondiscord.com',
             'pydis-api.default.svc.cluster.local',
+            gethostname(),
+            gethostbyname(gethostname())
         ]
     )
     SECRET_KEY = env('SECRET_KEY')

--- a/pydis_site/settings.py
+++ b/pydis_site/settings.py
@@ -14,7 +14,7 @@ import os
 import secrets
 import sys
 from pathlib import Path
-from socket import gethostname, gethostbyname
+from socket import gethostbyname, gethostname
 
 import environ
 import sentry_sdk


### PR DESCRIPTION
This is necessary to allow Prometheus to scrape the sites metrics endpoint.