### PR TITLE
Initialise metricity at runtime

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,6 @@ services:
       POSTGRES_DB: pysite
       POSTGRES_PASSWORD: pysite
       POSTGRES_USER: pysite
-    volumes:
-      - ./postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
 
   web:
     build:

--- a/manage.py
+++ b/manage.py
@@ -161,7 +161,6 @@ class SiteManager:
             exists = cursor.fetchone()
             if exists:
                 # Assume metricity is already populated if it exists
-                print("Metricity already exists, not creating.")
                 return
             print("Creating metricity relations and populating with some data.")
             cursor.execute("CREATE DATABASE metricity")
@@ -171,8 +170,8 @@ class SiteManager:
             database="metricity",
             **db_connection_kwargs
         )
-        with conn.cursor() as cursor:
-            cursor.execute(open("postgres/init.sql").read())
+        with conn.cursor() as cursor, open("postgres/init.sql", encoding="utf-8") as f:
+            cursor.execute(f.read())
 
     def prepare_server(self) -> None:
         """Perform preparation tasks before running the server."""

--- a/manage.py
+++ b/manage.py
@@ -153,6 +153,8 @@ class SiteManager:
         import psycopg2
         from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
+        print("Initialising metricity.")
+
         db_url_parts = SiteManager.parse_db_url(os.environ["DATABASE_URL"])
         conn = psycopg2.connect(
             host=db_url_parts.hostname,

--- a/manage.py
+++ b/manage.py
@@ -173,6 +173,7 @@ class SiteManager:
                 return
             print("Creating metricity relations and populating with some data.")
             cursor.execute("CREATE DATABASE metricity")
+        conn.close()
 
         # Switch connection to metricity and initialise some data
         conn = psycopg2.connect(
@@ -181,6 +182,7 @@ class SiteManager:
         )
         with conn.cursor() as cursor, open("postgres/init.sql", encoding="utf-8") as f:
             cursor.execute(f.read())
+        conn.close()
 
     def prepare_server(self) -> None:
         """Perform preparation tasks before running the server."""

--- a/manage.py
+++ b/manage.py
@@ -142,10 +142,10 @@ class SiteManager:
     @staticmethod
     def run_metricity_init() -> None:
         """
-        Initilise metricity relations and populate with some testing data.
+        Initialise metricity relations and populate with some testing data.
 
         This is done at run time since other projects, like Python bot,
-        rely on the site initilising it's own db, since they do not have
+        rely on the site initialising it's own db, since they do not have
         access to the init.sql file to mount a docker-compose volume.
         """
         import psycopg2

--- a/manage.py
+++ b/manage.py
@@ -229,9 +229,8 @@ class SiteManager:
 
 def main() -> None:
     """Entry point for Django management script."""
-    # Always run metricity init in CI
-    in_ci = os.environ.get("CI", "false").lower() == "true"
-    if in_ci:
+    # Always run metricity init when in CI, indicated by the CI env var
+    if os.environ.get("CI", "false").lower() == "true":
         SiteManager.wait_for_postgres()
         SiteManager.run_metricity_init()
 

--- a/manage.py
+++ b/manage.py
@@ -65,7 +65,9 @@ class SiteManager:
             db_url_parts.password,
             db_url_parts.path
         )):
-            raise OSError("Valid DATABASE_URL environment variable not found.")
+            raise ValueError(
+                "The DATABASE_URL environment variable is not a valid PostgreSQL database URL."
+            )
         return db_url_parts
 
     @staticmethod

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -1,8 +1,4 @@
-CREATE DATABASE metricity;
-
-\c metricity;
-
-CREATE TABLE users (
+CREATE TABLE IF NOT EXISTS users (
     id varchar,
     joined_at timestamp,
     primary key(id)
@@ -11,14 +7,14 @@ CREATE TABLE users (
 INSERT INTO users VALUES (
     0,
     current_timestamp
-);
+) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO users VALUES (
     1,
     current_timestamp
-);
+) ON CONFLICT (id) DO NOTHING;
 
-CREATE TABLE channels (
+CREATE TABLE IF NOT EXISTS channels (
     id varchar,
     name varchar,
     primary key(id)
@@ -27,44 +23,44 @@ CREATE TABLE channels (
 INSERT INTO channels VALUES(
     '267659945086812160',
     'python-general'
-);
+) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO channels VALUES(
     '11',
     'help-apple'
-);
+) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO channels VALUES(
     '12',
     'help-cherry'
-);
+) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO channels VALUES(
     '21',
     'ot0-hello'
-);
+) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO channels VALUES(
     '22',
     'ot1-world'
-);
+) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO channels VALUES(
     '31',
     'voice-chat-0'
-);
+) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO channels VALUES(
     '32',
     'code-help-voice-0'
-);
+) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO channels VALUES(
     '1234',
     'zebra'
-);
+) ON CONFLICT (id) DO NOTHING;
 
-CREATE TABLE messages (
+CREATE TABLE IF NOT EXISTS messages (
     id varchar,
     author_id varchar references users(id),
     is_deleted boolean,
@@ -79,7 +75,7 @@ INSERT INTO messages VALUES(
     false,
     now(),
     '267659945086812160'
-);
+) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO messages VALUES(
     1,
@@ -87,7 +83,7 @@ INSERT INTO messages VALUES(
     false,
     now() + INTERVAL '10 minutes,',
     '1234'
-);
+) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO messages VALUES(
     2,
@@ -95,7 +91,7 @@ INSERT INTO messages VALUES(
     false,
     now(),
     '11'
-);
+) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO messages VALUES(
     3,
@@ -103,7 +99,7 @@ INSERT INTO messages VALUES(
     false,
     now(),
     '12'
-);
+) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO messages VALUES(
     4,
@@ -111,7 +107,7 @@ INSERT INTO messages VALUES(
     false,
     now(),
     '21'
-);
+) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO messages VALUES(
     5,
@@ -119,7 +115,7 @@ INSERT INTO messages VALUES(
     false,
     now(),
     '22'
-);
+) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO messages VALUES(
     6,
@@ -127,7 +123,7 @@ INSERT INTO messages VALUES(
     false,
     now(),
     '31'
-);
+) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO messages VALUES(
     7,
@@ -135,7 +131,7 @@ INSERT INTO messages VALUES(
     false,
     now(),
     '32'
-);
+) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO messages VALUES(
     8,
@@ -143,4 +139,4 @@ INSERT INTO messages VALUES(
     true,
     now(),
     '32'
-);
+) ON CONFLICT (id) DO NOTHING;

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -1,3 +1,24 @@
+DO
+$do$
+DECLARE
+  _db TEXT := %s;
+  _user TEXT := %s;
+  _password TEXT := %s;
+BEGIN
+  CREATE EXTENSION IF NOT EXISTS dblink;
+  IF EXISTS (SELECT 1 FROM pg_database WHERE datname = _db) THEN
+    RAISE NOTICE 'Database already exists';
+  ELSE
+    PERFORM dblink_connect(
+        'host=localhost user=' || _user ||
+        ' password=' || _password ||
+        ' dbname=' || current_database()
+    );
+    PERFORM dblink_exec('CREATE DATABASE ' || _db);
+  END IF;
+END
+$do$;
+
 CREATE TABLE IF NOT EXISTS users (
     id varchar,
     joined_at timestamp,

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -1,3 +1,7 @@
+-- The following function is from Stack Overflow
+-- https://stackoverflow.com/questions/18389124/simulate-create-database-if-not-exists-for-postgresql/36218838#36218838
+-- User frankhommers (https://stackoverflow.com/users/971229/frankhommers)
+
 DO
 $do$
 DECLARE


### PR DESCRIPTION
Currently the bot cannot start in dev as the site errors, saying that metricity doesn't exist. Previously this note existing was fine, unless you needed to use metricity data. With the recent addition of django-prometheus, metricity is now required on boot.

This PR moves the init of metricity from a docker-compose volume, into running of the site. This means that external projects using site, that don't have access to the init.sql file to mount a volume, now also init metricity.