### PR TITLE
Update embed description length to 4096

### DIFF
--- a/pydis_site/apps/api/models/utils.py
+++ b/pydis_site/apps/api/models/utils.py
@@ -142,7 +142,7 @@ def validate_embed(embed: Any) -> None:
             ),
             MaxLengthValidator(limit_value=256)
         ),
-        'description': (MaxLengthValidator(limit_value=2048),),
+        'description': (MaxLengthValidator(limit_value=4096),),
         'fields': (
             MaxLengthValidator(limit_value=25),
             validate_embed_fields

--- a/pydis_site/apps/api/tests/test_validators.py
+++ b/pydis_site/apps/api/tests/test_validators.py
@@ -72,7 +72,7 @@ class TagEmbedValidatorTests(TestCase):
     def test_rejects_too_long_description(self):
         with self.assertRaises(ValidationError):
             validate_embed({
-                'description': 'd' * 2049
+                'description': 'd' * 4097
             })
 
     def test_allows_valid_embed(self):


### PR DESCRIPTION
Max embed description length was raised to 4096, but the API wasn't updated, causing logging to fail when trying to clean long embeds.