### PR TITLE
Update repository selection on home page

### DIFF
--- a/pydis_site/apps/home/tests/mock_github_api_response.json
+++ b/pydis_site/apps/home/tests/mock_github_api_response.json
@@ -21,7 +21,7 @@
     "forks_count": 31
   },
   {
-    "full_name": "python-discord/django-simple-bulma",
+    "full_name": "python-discord/king-arthur",
     "description": "test",
     "stargazers_count": 97,
     "language": "Python",

--- a/pydis_site/apps/home/views/home.py
+++ b/pydis_site/apps/home/views/home.py
@@ -27,7 +27,7 @@ class HomeView(View):
         "python-discord/snekbox",
         "python-discord/sir-lancebot",
         "python-discord/metricity",
-        "python-discord/django-simple-bulma",
+        "python-discord/king-arthur",
     ]
 
     def __init__(self):


### PR DESCRIPTION
In accordance with a poll in #dev-contrib, King Arthur becomes the 6th repository featured on the Python Discord homepage.