### PR TITLE
Fix typos across codebase

### DIFF
--- a/pydis_site/apps/api/tests/test_off_topic_channel_names.py
+++ b/pydis_site/apps/api/tests/test_off_topic_channel_names.py
@@ -154,7 +154,7 @@ class DeletionTests(AuthenticatedAPITestCase):
         cls.test_name_2 = OffTopicChannelName.objects.create(name='bbq-with-bisk')
 
     def test_deleting_unknown_name_returns_404(self):
-        """Return 404 reponse when trying to delete unknown name."""
+        """Return 404 response when trying to delete unknown name."""
         url = reverse('api:bot:offtopicchannelname-detail', args=('unknown-name',))
         response = self.client.delete(url)
 

--- a/pydis_site/apps/api/tests/test_offensive_message.py
+++ b/pydis_site/apps/api/tests/test_offensive_message.py
@@ -58,7 +58,7 @@ class CreationTests(AuthenticatedAPITestCase):
         )
 
         for field, invalid_value in cases:
-            with self.subTest(fied=field, invalid_value=invalid_value):
+            with self.subTest(field=field, invalid_value=invalid_value):
                 test_data = data.copy()
                 test_data.update({field: invalid_value})
 

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/issues.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/issues.md
@@ -56,7 +56,7 @@ Definitely try to:
 
 Labels allow us to better organise Issues by letting us view what type of Issue it is, how it might impact the codebase and at what stage it's at.
 
-In our repositories, we try to prefix labels belonging to the same group, for example the label groups `status` or `type`.  We will be trying to keep to the same general structure across our project repositories, but just have a look at the full lables list in the respective repository to get a clear idea what's available.
+In our repositories, we try to prefix labels belonging to the same group, for example the label groups `status` or `type`.  We will be trying to keep to the same general structure across our project repositories, but just have a look at the full labels list in the respective repository to get a clear idea what's available.
 
 If you're a contributor, you can add relevant labels yourself to any new Issue ticket you create.
 

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/sir-lancebot.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/sir-lancebot.md
@@ -96,7 +96,7 @@ Otherwise, please see the below linked guide for Redis related variables.
 
 ---
 # Run the project
-The sections below describe the two ways you can run this project. We recomend Docker as it requires less setup.
+The sections below describe the two ways you can run this project. We recommend Docker as it requires less setup.
 
 ## Run with Docker
 Make sure to have Docker running, then use the Docker command `docker-compose up` in the project root.

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/sir-lancebot/env-var-reference.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/sir-lancebot/env-var-reference.md
@@ -61,10 +61,10 @@ These variables might come in handy while working on certain cogs:
 
 | Cog | Environment Variable | Description |
 | -------- | -------- | -------- |
-| Advent of Code | `AOC_LEADERBOARDS` | List of leaderboards seperated by `::`. Each entry should have an `id,session cookie,join code` seperated by commas in that order. |
+| Advent of Code | `AOC_LEADERBOARDS` | List of leaderboards separated by `::`. Each entry should have an `id,session cookie,join code` separated by commas in that order. |
 | Advent of Code | `AOC_STAFF_LEADERBOARD_ID` | Integer ID of the staff leaderboard. |
 | Advent of Code | `AOC_ROLE_ID` | ID of the advent of code role.
-| Advent of Code | `AOC_IGNORED_DAYS` | Comma seperated list of days to ignore while calculating score. |
+| Advent of Code | `AOC_IGNORED_DAYS` | Comma separated list of days to ignore while calculating score. |
 | Advent of Code | `AOC_YEAR` | Debug variable to change the year used for AoC. |
 | Advent of Code | `AOC_CHANNEL_ID` | The ID of the #advent-of-code channel |
 | Advent of Code | `AOC_COMMANDS_CHANNEL_ID` | The ID of the #advent-of-code-commands channel |

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/sir-lancebot/env-var-reference.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/sir-lancebot/env-var-reference.md
@@ -26,7 +26,7 @@ Additionally, you may find the following environment variables useful during dev
 | `BOT_DEBUG` | Debug mode of the bot | False |
 | `PREFIX` | The bot's invocation prefix | `.` |
 | `CYCLE_FREQUENCY` | Amount of days between cycling server icon | 3 |
-| `MONTH_OVERRIDE` | Interger in range `[0, 12]`, overrides current month w.r.t. seasonal decorators |
+| `MONTH_OVERRIDE` | Integer in range `[0, 12]`, overrides current month w.r.t. seasonal decorators |
 | `REDIS_HOST` | The address to connect to for the Redis database. |
 | `REDIS_PORT` | |
 | `REDIS_PASSWORD` | |
@@ -64,7 +64,7 @@ These variables might come in handy while working on certain cogs:
 | Advent of Code | `AOC_LEADERBOARDS` | List of leaderboards seperated by `::`. Each entry should have an `id,session cookie,join code` seperated by commas in that order. |
 | Advent of Code | `AOC_STAFF_LEADERBOARD_ID` | Integer ID of the staff leaderboard. |
 | Advent of Code | `AOC_ROLE_ID` | ID of the advent of code role.
-| Advent of Code | `AOC_IGNORED_DAYS` | Comma seperated list of days to ignore while calulating score. |
+| Advent of Code | `AOC_IGNORED_DAYS` | Comma seperated list of days to ignore while calculating score. |
 | Advent of Code | `AOC_YEAR` | Debug variable to change the year used for AoC. |
 | Advent of Code | `AOC_CHANNEL_ID` | The ID of the #advent-of-code channel |
 | Advent of Code | `AOC_COMMANDS_CHANNEL_ID` | The ID of the #advent-of-code-commands channel |

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/site.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/site.md
@@ -108,7 +108,7 @@ If you get any Docker related errors, reference the [Possible Issues](https://py
 
 ## Run on the host
 
-Running on the host is particularily useful if you wish to debug the site. The [environment variables](#2-environment-variables) shown in a previous section need to have been configured.
+Running on the host is particularly useful if you wish to debug the site. The [environment variables](#2-environment-variables) shown in a previous section need to have been configured.
 
 ### Database
 

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/working-with-git/cli.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/working-with-git/cli.md
@@ -27,7 +27,7 @@ If you use SSH, use `git@github.com:python-discord/sir-lancebot.git` for the ups
 You will be committing your changes to a new branch rather than to `main`.
 Using branches allows you to work on muiltiple pull requests without conflicts.
 
-You can name your branch whatever you want, but it's recommended to name it something succint and relevant to the changes you will be making.
+You can name your branch whatever you want, but it's recommended to name it something succinct and relevant to the changes you will be making.
 
 Run the following commands to create a new branch. Replace `branch_name` with the name you wish to give your branch.
 ```sh

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/working-with-git/pycharm.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/working-with-git/pycharm.md
@@ -27,7 +27,7 @@ The following will use the [Sir-Lancebot](https://github.com/python-discord/sir-
 ## Creating a New Branch
 > You will be committing your changes to a new branch rather than to `main`. Using branches allows you to work on multiple pull requests at the same time without conflicts.
 
-> You can name your branch whatever you want, but it's recommended to name it something succint and relevant to the changes you will be making.
+> You can name your branch whatever you want, but it's recommended to name it something succinct and relevant to the changes you will be making.
 
 > Before making new branches, be sure to checkout the `main` branch and ensure it's up to date.
 

--- a/pydis_site/apps/content/resources/guides/pydis-guides/helping-others.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/helping-others.md
@@ -112,7 +112,7 @@ Presenting a solution that is considered a bad practice might be useful in certa
 >     for i in range(len(your_list)):
 >         print(your_list[i])
 >
-> The second replier gave a valid solution, but it's important that he clarifies that it is concidered a bad practice in Python, and that the first solution should usually be used in this case.
+> The second replier gave a valid solution, but it's important that he clarifies that it is considered a bad practice in Python, and that the first solution should usually be used in this case.
 
 
 ## It's OK to Step Away

--- a/pydis_site/apps/resources/resources/tools/ides/thonny.yaml
+++ b/pydis_site/apps/resources/resources/tools/ides/thonny.yaml
@@ -1,4 +1,4 @@
-description: A Python IDE specifially aimed at learning programming. Has a lot of
+description: A Python IDE specifically aimed at learning programming. Has a lot of
   helpful features to help you understand your code.
 name: Thonny
 title_url: https://thonny.org/


### PR DESCRIPTION
## Changes
-  `./pydis_site/apps/resources/resources/tools/ides/thonny.yaml:1`: specifically
- `./pydis_site/apps/content/resources/guides/pydis-guides/helping-others.md:115`: considered
- `./pydis_site/apps/content/resources/guides/pydis-guides/contributing/issues.md`:59 labels
- `./pydis_site/apps/content/resources/guides/pydis-guides/contributing/sir-lancebot.md:99`: recommend
- `./pydis_site/apps/content/resources/guides/pydis-guides/contributing/site.md:111`: particularly
- `./pydis_site/apps/content/resources/guides/pydis-guides/contributing/sir-lancebot/env-var-reference.md:29`: Integer
- `./pydis_site/apps/content/resources/guides/pydis-guides/contributing/sir-lancebot/env-var-reference.md:67`: calculating
- `./pydis_site/apps/api/tests/test_off_topic_channel_names.py:157`: response


## Notes
- I didn't touch the code jam and game jam typos because I'm think they should probably be preserved as is since it's a historical thing.
- There were a few 'seperated' typos which I didn't change because I *think* it's just another way of spelling it?
- In the offensive words test there was a keyword argument named `fied` which I didn't touch because I wasn't sure where that was from.