### PR TITLE
Easy docker migrations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
     volumes:
       - .:/app:ro
       - staticfiles:/var/www/static
+      - ./pydis_site/api/migrations:/app/pydis_site/api/migrations
+      - ./pydis_site/home/migrations:/app/pydis_site/home/migrations
     environment:
       DATABASE_URL: postgres://pysite:pysite@postgres:5432/pysite
       METRICITY_DB_URL: postgres://pysite:pysite@postgres:5432/metricity

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       retries: 5
     volumes:
       - ./postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - pgdata:/var/lib/postgresql/data
 
   web:
     build:
@@ -57,3 +58,4 @@ services:
 
 volumes:
   staticfiles:
+  pgdata:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.taskipy.tasks]
 start = "python manage.py run --debug"
 makemigrations = "python manage.py makemigrations"
+dockermigrations = "docker-compose exec web python /app/manage.py makemigrations"
 django_shell = "python manage.py shell"
 test = "coverage run manage.py test"
 report = "coverage report -m"


### PR DESCRIPTION
This PR adds two things
1. An easy way to generate migrations running under a pure docker setup
   - Simply run `poetry run task dockermigrations` and all the migrations will be created
   - Under the hood this calls docker exec and then through the magic of volumes it appears in the local system
2. Add a persistent volume for postgres data
   - This means `docker-compose down` won't lose your db data anymore.
   - If needed you can still do `docker-compose down --volumes`