### PR TITLE
Don't always calc activity blocks

### DIFF
--- a/pydis_site/apps/api/tests/test_users.py
+++ b/pydis_site/apps/api/tests/test_users.py
@@ -428,6 +428,25 @@ class UserMetricityTests(AuthenticatedAPITestCase):
             "activity_blocks": total_blocks
         })
 
+    def test_get_metricity_data_over_1k(self):
+        # Given
+        joined_at = "foo"
+        total_messages = 1001
+        total_blocks = 1001
+        self.mock_metricity_user(joined_at, total_messages, total_blocks, [])
+
+        # When
+        url = reverse('api:bot:user-metricity-data', args=[0])
+        response = self.client.get(url)
+
+        # Then
+        self.assertEqual(response.status_code, 200)
+        self.assertCountEqual(response.json(), {
+            "joined_at": joined_at,
+            "total_messages": total_messages,
+            "voice_banned": False,
+        })
+
     def test_no_metricity_user(self):
         # Given
         self.mock_no_metricity_user()

--- a/pydis_site/apps/api/tests/test_users.py
+++ b/pydis_site/apps/api/tests/test_users.py
@@ -408,7 +408,7 @@ class UserMetricityTests(AuthenticatedAPITestCase):
             in_guild=True,
         )
 
-    def test_get_metricity_data(self):
+    def test_get_metricity_data_under_1k(self):
         # Given
         joined_at = "foo"
         total_messages = 1
@@ -421,7 +421,7 @@ class UserMetricityTests(AuthenticatedAPITestCase):
 
         # Then
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {
+        self.assertCountEqual(response.json(), {
             "joined_at": joined_at,
             "total_messages": total_messages,
             "voice_banned": False,

--- a/pydis_site/apps/api/viewsets/bot/user.py
+++ b/pydis_site/apps/api/viewsets/bot/user.py
@@ -271,9 +271,15 @@ class UserViewSet(ModelViewSet):
         with Metricity() as metricity:
             try:
                 data = metricity.user(user.id)
+
                 data["total_messages"] = metricity.total_messages(user.id)
+                if data["total_messages"] < 1000:
+                    # Only calculate and return activity_blocks if the user has a small amount
+                    # of messages, as calculating activity_blocks is expensive.
+                    # 1000 message chosen as an arbitrarily large number.
+                    data["activity_blocks"] = metricity.total_message_blocks(user.id)
+
                 data["voice_banned"] = voice_banned
-                data["activity_blocks"] = metricity.total_message_blocks(user.id)
                 return Response(data, status=status.HTTP_200_OK)
             except NotFoundError:
                 return Response(dict(detail="User not found in metricity"),


### PR DESCRIPTION
https://github.com/python-discord/bot/pull/1971 must be merged before this.

We only truly care about how many activity blocks a user has when they have a small number of messages, as we only use this for the voice gate.

If a user has more than say 1k messages, then we really don't need to calculate their activity blocks, as it's quite an expensive query with many messages.

Also, for the tests we only actually care that thee key:value pairs are equal, the order of them isn't actually important.

The naming of `assertCountEqual` is a little misleading, since it actually tests that the first sequence contains the same elements as second, regardless of their order. See https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertCountEqual