### PR TITLE
Query message count directly from messages

### DIFF
--- a/pydis_site/apps/api/models/bot/metricity.py
+++ b/pydis_site/apps/api/models/bot/metricity.py
@@ -46,12 +46,14 @@ class Metricity:
         self.cursor.execute(
             """
             SELECT
-                message_count
-            FROM user_has_approx_message_count
+                COUNT(*)
+            FROM messages
             WHERE
                 author_id = '%s'
+                AND NOT is_deleted
+                AND channel_id NOT IN %s
             """,
-            [user_id]
+            [user_id, EXCLUDE_CHANNELS]
         )
         values = self.cursor.fetchone()
 


### PR DESCRIPTION
This was changed due to performance reasons, but after some tweaking in the database, such as increasing work memory and adding an index, this query runs much faster now.

To test this, I want to revert this change, so that we can stop the materialised view from refreshing, to see if the act of refreshing is what's causing this query to seem faster when runing against the database.