### PR TITLE
Always include metricity message blocks

### DIFF
--- a/pydis_site/apps/api/tests/test_users.py
+++ b/pydis_site/apps/api/tests/test_users.py
@@ -408,7 +408,7 @@ class UserMetricityTests(AuthenticatedAPITestCase):
             in_guild=True,
         )
 
-    def test_get_metricity_data_under_1k(self):
+    def test_get_metricity_data(self):
         # Given
         joined_at = "foo"
         total_messages = 1
@@ -426,25 +426,6 @@ class UserMetricityTests(AuthenticatedAPITestCase):
             "total_messages": total_messages,
             "voice_banned": False,
             "activity_blocks": total_blocks
-        })
-
-    def test_get_metricity_data_over_1k(self):
-        # Given
-        joined_at = "foo"
-        total_messages = 1001
-        total_blocks = 1001
-        self.mock_metricity_user(joined_at, total_messages, total_blocks, [])
-
-        # When
-        url = reverse('api:bot:user-metricity-data', args=[0])
-        response = self.client.get(url)
-
-        # Then
-        self.assertEqual(response.status_code, 200)
-        self.assertCountEqual(response.json(), {
-            "joined_at": joined_at,
-            "total_messages": total_messages,
-            "voice_banned": False,
         })
 
     def test_no_metricity_user(self):

--- a/pydis_site/apps/api/viewsets/bot/user.py
+++ b/pydis_site/apps/api/viewsets/bot/user.py
@@ -273,11 +273,7 @@ class UserViewSet(ModelViewSet):
                 data = metricity.user(user.id)
 
                 data["total_messages"] = metricity.total_messages(user.id)
-                if data["total_messages"] < 1000:
-                    # Only calculate and return activity_blocks if the user has a small amount
-                    # of messages, as calculating activity_blocks is expensive.
-                    # 1000 message chosen as an arbitrarily large number.
-                    data["activity_blocks"] = metricity.total_message_blocks(user.id)
+                data["activity_blocks"] = metricity.total_message_blocks(user.id)
 
                 data["voice_banned"] = voice_banned
                 return Response(data, status=status.HTTP_200_OK)


### PR DESCRIPTION
Thanks to a recent database maintenance (https://pythondiscord.freshstatus.io/incident/139811) querying out metricity message data is far cheaper. So there is no longer a reason to only fetch blocks if the member has a low message count.