### PR TITLE
Prevent page title from overlapping dropdown button.

### DIFF
--- a/pydis_site/templates/content/dropdown.html
+++ b/pydis_site/templates/content/dropdown.html
@@ -1,4 +1,4 @@
-<div class="dropdown is-pulled-right is-right" id="dropdown">
+<div class="dropdown is-pulled-right is-right" id="dropdown" style="z-index: 1">
     <div class="dropdown-trigger">
         <a aria-haspopup="true" aria-controls="subarticle-menu">
             <span>Sub-Articles</span>


### PR DESCRIPTION
On clients with a small viewport width, the content title of pages overlap the "Sub-Articles" dropdown button due to having the same z-index, causing the element last positioned in the HTML to show up on top.

Fixes #643.