### PR TITLE
Fix pynews config in example file

### DIFF
--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot.md
@@ -350,7 +350,7 @@ style:
 
         trashcan: "<:trashcan:�>"
 
-##### <<  Optional - If you don't care about the filtering and help channel cogs, ignore the rest of this file  >> #####
+##### <<  Optional - If you don't care about the filtering, help channel and py-news cogs, ignore the rest of this file  >> #####
 filter:
     # What do we filter?
     filter_domains:        true
@@ -425,6 +425,10 @@ help_channels:
     # Mention these roles in notifications
     notify_roles:
         - *HELPERS_ROLE
+
+python_news:
+    channel: *DEV_PY_NEWS
+    webhook: *PYNEWS_WEBHOOK
 
 ##### <<  Add any additional sections you need to override from config-default.yml  >> #####
             </code>

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot.md
@@ -196,6 +196,7 @@ guild:
         big_brother:                            �
         dev_log:                                �
         duck_pond:                              �
+        incidents:                              �
         incidents_archive:                      �
         python_news:        &PYNEWS_WEBHOOK     �
         talent_pool:                            �


### PR DESCRIPTION
The python news cog relies on the python_news section of the config being filled in via a named alias. Since we were using the `DEV_` prefix, this meant it was not being populated, leading to the cog throwing an error on boot.

This PR also adds the new incidents webhook that is used for message unfurling.