### PR TITLE
Replace FA pro issue icon with the regular icon

### DIFF
--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing.md
@@ -27,7 +27,7 @@ Our projects on Python Discord are open source and [available on Github](https:/
         </div>
       </div>
       <div class="card-footer">
-        <a href="https://github.com/python-discord/sir-lancebot/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc" class="card-footer-item"><i class="far fa-exclamation-circle"></i>&ensp;Issues</a>
+        <a href="https://github.com/python-discord/sir-lancebot/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc" class="card-footer-item"><i class="fas fa-exclamation-circle"></i>&ensp;Issues</a>
         <a href="https://github.com/python-discord/sir-lancebot/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc" class="card-footer-item"><i class="fas fa-code-merge"></i>&ensp;PRs</a>
       </div>
       <div class="card-footer">
@@ -54,7 +54,7 @@ Our projects on Python Discord are open source and [available on Github](https:/
         </div>
       </div>
       <div class="card-footer">
-        <a href="https://github.com/python-discord/bot/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc" class="card-footer-item"><i class="far fa-exclamation-circle"></i>&ensp;Issues</a>
+        <a href="https://github.com/python-discord/bot/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc" class="card-footer-item"><i class="fas fa-exclamation-circle"></i>&ensp;Issues</a>
         <a href="https://github.com/python-discord/bot/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc" class="card-footer-item"><i class="fas fa-code-merge"></i>&ensp;PRs</a>
       </div>
       <div class="card-footer">
@@ -81,7 +81,7 @@ Our projects on Python Discord are open source and [available on Github](https:/
         </div>
       </div>
       <div class="card-footer">
-        <a href="https://github.com/python-discord/site/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc" class="card-footer-item"><i class="far fa-exclamation-circle"></i>&ensp;Issues</a>
+        <a href="https://github.com/python-discord/site/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc" class="card-footer-item"><i class="fas fa-exclamation-circle"></i>&ensp;Issues</a>
         <a href="https://github.com/python-discord/site/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc" class="card-footer-item"><i class="fas fa-code-merge"></i>&ensp;PRs</a>
       </div>
       <div class="card-footer">


### PR DESCRIPTION
We stopped using FA pro, as we were using an ex-admin's person FA pro subscription, which we didn't control.

Before:
![image](https://user-images.githubusercontent.com/9753350/152564050-01f60f52-ba23-4106-9898-3f98cab11342.png)

After:
![image](https://user-images.githubusercontent.com/9753350/152564183-90de4034-ca3a-4390-8b68-4d86bd60df91.png)
