### PR TITLE
Remove the admin app

### DIFF
--- a/pydis_site/apps/admin/urls.py
+++ b/pydis_site/apps/admin/urls.py
@@ -1,8 +1,0 @@
-from django.contrib import admin
-from django.urls import path
-
-
-app_name = 'admin'
-urlpatterns = (
-    path('', admin.site.urls),
-)


### PR DESCRIPTION
This app is completely unused. I assume it was planned to be a space for
customizing the Django admin, but we don't even have it in
`INSTALLED_APPS`, nor our URLs.