### PR TITLE
Add channel ID to message deletion logs

### DIFF
--- a/pydis_site/templates/staff/logs.html
+++ b/pydis_site/templates/staff/logs.html
@@ -18,8 +18,12 @@
         <div class="discord-message">
             <div class="discord-message-header">
                 <span class="discord-username"
-                      style="color: {{ message.author.top_role.colour | hex_colour }}">{{ message.author }}</span><span
-                    class="discord-message-metadata has-text-grey">{{ message.timestamp }} | User ID: {{ message.author.id }}</span>
+                      style="color: {{ message.author.top_role.colour | hex_colour }}">{{ message.author }}
+                </span>
+                <span class="discord-message-metadata has-text-grey">
+                    User ID: {{ message.author.id }}<br>
+                    {{ message.timestamp }} (Channel ID: {{ message.channel_id }})
+                </span>
             </div>
             <div class="discord-message-content">
                 {{ message.content | escape | visible_newlines | safe }}


### PR DESCRIPTION
Closes #620.

The channel ID is now shown in message deletion logs.

Zoomed in on one log message:
![image](https://user-images.githubusercontent.com/47674925/155623688-d3ed3862-8a96-46a5-af70-91d0158c01a5.png)


Fullscreen page:
![image](https://user-images.githubusercontent.com/47674925/155623819-a5b26a5f-d83f-49ac-be81-77051bdad213.png)