### PR TITLE
Support color string being when converting to hex code

### DIFF
--- a/pydis_site/apps/staff/templatetags/deletedmessage_filters.py
+++ b/pydis_site/apps/staff/templatetags/deletedmessage_filters.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Union
 
 from django import template
 
@@ -6,13 +7,16 @@ register = template.Library()
 
 
 @register.filter
-def hex_colour(color: int) -> str:
+def hex_colour(colour: Union[str, int]) -> str:
     """
-    Converts an integer representation of a colour to the RGB hex value.
+    Converts the given representation of a colour to its RGB hex string.
 
     As we are using a Discord dark theme analogue, black colours are returned as white instead.
     """
-    colour = f"#{color:0>6X}"
+    if isinstance(colour, str):
+        colour = colour if colour.startswith("#") else f"#{colour}"
+    else:
+        colour = f"#{colour:0>6X}"
     return colour if colour != "#000000" else "#FFFFFF"
 
 

--- a/pydis_site/apps/staff/tests/test_logs_view.py
+++ b/pydis_site/apps/staff/tests/test_logs_view.py
@@ -95,12 +95,22 @@ class TestLogsView(TestCase):
             "description": "This embed is way too cool to be seen in public channels.",
         }
 
+        cls.embed_three = {
+            "description": "This embed is way too cool to be seen in public channels.",
+            "color": "#e74c3c",
+        }
+
+        cls.embed_four = {
+            "description": "This embed is way too cool to be seen in public channels.",
+            "color": "e74c3c",
+        }
+
         cls.deleted_message_two = DeletedMessage.objects.create(
             author=cls.author,
             id=614444836291870750,
             channel_id=1984,
             content='Does that mean this thing will halt?',
-            embeds=[cls.embed_one, cls.embed_two],
+            embeds=[cls.embed_one, cls.embed_two, cls.embed_three, cls.embed_four],
             attachments=['https://http.cat/100', 'https://http.cat/402'],
             deletion_context=cls.deletion_context,
         )


### PR DESCRIPTION
Int he latest version of discord.py Embed colours could be sent to site as hex strings, if set using a discord.Color, rather tha an int.

Closes #715 Closes SITE-25