### PR TITLE
Force line breaks at arbritrary points for really long words

### DIFF
--- a/pydis_site/static/css/staff/logs.css
+++ b/pydis_site/static/css/staff/logs.css
@@ -25,7 +25,10 @@ main.site-content {
 
 .discord-message:first-child {
     border-top: 1px;
+}
 
+.discord-message-content {
+    overflow-wrap: break-word;
 }
 
 .discord-message-header {


### PR DESCRIPTION
Currently if a message contains a very long word the content doesn't wrap and extends off the page.
![image](https://user-images.githubusercontent.com/75038675/165436192-45156fe7-a527-457d-a19d-3c4deeed1600.png)

This PR forces line breaks in what normally are unbreakable words.
![image](https://user-images.githubusercontent.com/75038675/165436029-cad45c2d-21d9-4f44-aefa-8d497f159f04.png)
