### PR TITLE
Fix interactive timeline icons.

### DIFF
--- a/pydis_site/static/css/home/index.css
+++ b/pydis_site/static/css/home/index.css
@@ -126,8 +126,7 @@ h1 {
     margin: 0 4% 0 4%;
     background-color: #3EB2EF;
     color: white;
-    font-size: 15px;
-    line-height: 33px;
+    line-height: 31px;
     border:none;
     box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
     transition: all 0.3s cubic-bezier(.25,.8,.25,1);

--- a/pydis_site/templates/home/index.html
+++ b/pydis_site/templates/home/index.html
@@ -99,9 +99,9 @@
             <div class="mini-timeline">
               <i class="fa fa-asterisk"></i>
               <i class="fa fa-code"></i>
-              <i class="fab fa-python"></i>
+              <i class="fab fa-lg fa-python"></i>
               <i class="fab fa-discord"></i>
-              <i class="fa fa-terminal"></i>
+              <i class="fa fa-sm fa-terminal"></i>
               <i class="fa fa-bug"></i>
             </div>
 

--- a/pydis_site/templates/home/index.html
+++ b/pydis_site/templates/home/index.html
@@ -100,8 +100,8 @@
               <i class="fa fa-asterisk"></i>
               <i class="fa fa-code"></i>
               <i class="fab fa-python"></i>
-              <i class="fa fa-alien-monster"></i>
-              <i class="fa fa-duck"></i>
+              <i class="fab fa-discord"></i>
+              <i class="fa fa-terminal"></i>
               <i class="fa fa-bug"></i>
             </div>
 


### PR DESCRIPTION
## Details
`fa-duck` and `fa-alien-monster` (renamed `fa-alien-8bit` in the latest
FontAwesome) are part of the Pro plan, which we no longer have.

I replaced `fa-alien-monster` with `fa-discord` for a nice "python discord" in the center, and `fa-duck` with `fa-terminal` to match `fa-code` on the other side.

Icon size and alignment are also adjusted for better visual clarity.

Thanks to @LemonPi314 for pointing out the issue.

## Current
![image](https://user-images.githubusercontent.com/41782385/175852522-d428fcfb-19cc-4f62-ad8e-7304d97f39f7.png)

## New
![image](https://user-images.githubusercontent.com/41782385/175852534-085a97c7-ebd8-4f9d-a5a0-24b69cd20f76.png)
