### PR TITLE
Rework and reorder CJ9 framework descriptions

### DIFF
--- a/pydis_site/templates/events/pages/code-jams/9/frameworks.html
+++ b/pydis_site/templates/events/pages/code-jams/9/frameworks.html
@@ -94,6 +94,10 @@
                 <p class="is-italic">ASGI is the specification your favourite frameworks are built on. This is not a framework in of itself, but listed here for completeness.</p>
             </div>
         </div>
+        <div class="card-footer">
+            <a href="https://asgi.readthedocs.io/en/latest/" class="card-fotter-item"><i class="fa-clipboard-list"></i>Specification</a>
+        </div>
+    </div>
 
     <div class="card mb-4">
         <div class="card-content">

--- a/pydis_site/templates/events/pages/code-jams/9/frameworks.html
+++ b/pydis_site/templates/events/pages/code-jams/9/frameworks.html
@@ -94,7 +94,7 @@
             </div>
         </div>
         <div class="card-footer">
-            <a href="https://asgi.readthedocs.io/en/latest/" class="card-fotter-item"><i class="fas fa-clipboard-list"></i>&ensp;Specification</a>
+            <a href="https://asgi.readthedocs.io/en/latest/" class="card-footer-item"><i class="fas fa-clipboard-list"></i>&ensp;Specification</a>
         </div>
     </div>
 

--- a/pydis_site/templates/events/pages/code-jams/9/frameworks.html
+++ b/pydis_site/templates/events/pages/code-jams/9/frameworks.html
@@ -21,7 +21,7 @@
         <div class="card-content">
             <div class="content">
                 <p class="subtitle">FastAPI</p>
-                <p class="is-italic">FastAPI is a modern, fast (high-performance), web framework for building APIs with Python 3.6+ based on standard Python type hints.
+                <p class="is-italic">FastAPI is a modern web framework great for WebSockets based on standard Python type hints which provides great editor support.
                 </p>
             </div>
         </div>
@@ -49,8 +49,7 @@
         <div class="card-content">
             <div class="content">
                 <p class="subtitle">websockets</p>
-                <p class="is-italic">websockets is a library for building WebSocket servers and clients in Python with a focus on correctness, simplicity, robustness, and performance.
-                    Built on top of asyncio, Python’s standard asynchronous I/O framework, it provides an elegant coroutine-based API.
+                <p class="is-italic">websockets is a library for building both WebSocket clients and servers with focus on simplicity and performance.
                 </p>
             </div>
         </div>
@@ -64,8 +63,7 @@
         <div class="card-content">
             <div class="content">
                 <p class="subtitle">Django Channels</p>
-                <p class="is-italic">Channels is a project that takes Django and extends its abilities beyond HTTP - to handle WebSockets, chat protocols, IoT protocols, and more.
-                    It’s built on a Python specification called ASGI.
+                <p class="is-italic">Django Channels adds WebSocket-support to Django - built on ASGI like other web frameworks.
                 </p>
             </div>
         </div>
@@ -93,9 +91,7 @@
         <div class="card-content">
             <div class="content">
                 <p class="subtitle">wsproto</p>
-                <p class="is-italic">wsproto is a WebSocket protocol stack written to be as flexible as possible.
-                    To that end it is written in pure Python and performs no I/O of its own.
-                    Instead it relies on the user to provide a bridge between it and whichever I/O mechanism is in use, allowing it to be used in single-threaded, multi-threaded or event-driven code.
+                <p class="is-italic">wsproto is a pure-Python WebSocket protocol stack written to be as flexible as possible by having the user build the bridge to the I/O.
                 </p>
             </div>
         </div>

--- a/pydis_site/templates/events/pages/code-jams/9/frameworks.html
+++ b/pydis_site/templates/events/pages/code-jams/9/frameworks.html
@@ -17,7 +17,7 @@
         If there is a library not listed below that you think should be here, you're welcome to discuss it with the Events Team over at <a href="https://discord.gg/HnGd3znxhJ">the server</a>.
     </p>
 
-    <div class="card mb">
+    <div class="card mb-4">
         <div class="card-content">
             <div class="content">
                 <p class="subtitle">FastAPI</p>

--- a/pydis_site/templates/events/pages/code-jams/9/frameworks.html
+++ b/pydis_site/templates/events/pages/code-jams/9/frameworks.html
@@ -21,8 +21,7 @@
         <div class="card-content">
             <div class="content">
                 <p class="subtitle">FastAPI</p>
-                <p class="is-italic">FastAPI is a modern web framework great for WebSockets based on standard Python type hints which provides great editor support.
-                </p>
+                <p>FastAPI is a modern web framework great for WebSockets based on standard Python type hints which provides great editor support.</p>
             </div>
         </div>
         <div class="card-footer">
@@ -35,7 +34,7 @@
         <div class="card-content">
             <div class="content">
                 <p class="subtitle">Starlette</p>
-                <p class="is-italic">Starlette is a lightweight ASGI framework/toolkit, which is ideal for building async web services in Python.
+                <p>Starlette is a lightweight ASGI framework/toolkit, which is ideal for building async web services in Python.
                 </p>
             </div>
         </div>
@@ -49,7 +48,7 @@
         <div class="card-content">
             <div class="content">
                 <p class="subtitle">websockets</p>
-                <p class="is-italic">websockets is a library for building both WebSocket clients and servers with focus on simplicity and performance.
+                <p>websockets is a library for building both WebSocket clients and servers with focus on simplicity and performance.
                 </p>
             </div>
         </div>
@@ -63,7 +62,7 @@
         <div class="card-content">
             <div class="content">
                 <p class="subtitle">Django Channels</p>
-                <p class="is-italic">Django Channels adds WebSocket-support to Django - built on ASGI like other web frameworks.
+                <>Django Channels adds WebSocket-support to Django - built on ASGI like other web frameworks.
                 </p>
             </div>
         </div>
@@ -77,7 +76,7 @@
         <div class="card-content">
             <div class="content">
                 <p class="subtitle">Flask-SocketIO</p>
-                <p class="is-italic">Flask-SocketIO gives Flask applications access to low latency bi-directional communications between the clients and the server.
+                <p>Flask-SocketIO gives Flask applications access to low latency bi-directional communications between the clients and the server.
                 </p>
             </div>
         </div>
@@ -91,7 +90,7 @@
         <div class="card-content">
             <div class="content">
                 <p class="subtitle">ASGI</p>
-                <p class="is-italic">ASGI is the specification your favourite frameworks are built on. This is not a framework in of itself, but listed here for completeness.</p>
+                <p>ASGI is the specification your favourite frameworks are built on. This is not a framework in of itself, but listed here for completeness.</p>
             </div>
         </div>
         <div class="card-footer">
@@ -103,7 +102,7 @@
         <div class="card-content">
             <div class="content">
                 <p class="subtitle">wsproto</p>
-                <p class="is-italic">wsproto is a pure-Python WebSocket protocol stack written to be as flexible as possible by having the user build the bridge to the I/O.
+                <p>wsproto is a pure-Python WebSocket protocol stack written to be as flexible as possible by having the user build the bridge to the I/O.
                 </p>
             </div>
         </div>

--- a/pydis_site/templates/events/pages/code-jams/9/frameworks.html
+++ b/pydis_site/templates/events/pages/code-jams/9/frameworks.html
@@ -16,6 +16,35 @@
         Please work with your team to choose a library that everyone can and want to develop with.
         If there is a library not listed below that you think should be here, you're welcome to discuss it with the Events Team over at <a href="https://discord.gg/HnGd3znxhJ">the server</a>.
     </p>
+
+    <div class="card mb">
+        <div class="card-content">
+            <div class="content">
+                <p class="subtitle">FastAPI</p>
+                <p class="is-italic">FastAPI is a modern, fast (high-performance), web framework for building APIs with Python 3.6+ based on standard Python type hints.
+                </p>
+            </div>
+        </div>
+        <div class="card-footer">
+            <a href="https://fastapi.tiangolo.com/advanced/websockets" class="card-footer-item"><i class="fas fa-book"></i>&ensp;Documentation</a>
+            <a href="https://github.com/tiangolo/fastapi" class="card-footer-item"><i class="fab fa-github"></i>&ensp;GitHub</a>
+        </div>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-content">
+            <div class="content">
+                <p class="subtitle">Starlette</p>
+                <p class="is-italic">Starlette is a lightweight ASGI framework/toolkit, which is ideal for building async web services in Python.
+                </p>
+            </div>
+        </div>
+        <div class="card-footer">
+            <a href="https://www.starlette.io/websockets" class="card-footer-item"><i class="fas fa-book"></i>&ensp;Documentation</a>
+            <a href="https://github.com/encode/starlette" class="card-footer-item"><i class="fab fa-github"></i>&ensp;GitHub</a>
+        </div>
+    </div>
+
     <div class="card mb-4">
         <div class="card-content">
             <div class="content">
@@ -30,19 +59,7 @@
             <a href="https://github.com/aaugustin/websockets" class="card-footer-item"><i class="fab fa-github"></i>&ensp;GitHub</a>
         </div>
     </div>
-    <div class="card mb-4">
-        <div class="card-content">
-            <div class="content">
-                <p class="subtitle">Flask-SocketIO</p>
-                <p class="is-italic">Flask-SocketIO gives Flask applications access to low latency bi-directional communications between the clients and the server.
-                </p>
-            </div>
-        </div>
-        <div class="card-footer">
-            <a href="https://flask-socketio.readthedocs.io/en/latest" class="card-footer-item"><i class="fas fa-book"></i>&ensp;Documentation</a>
-            <a href="https://github.com/miguelgrinberg/flask-socketio" class="card-footer-item"><i class="fab fa-github"></i>&ensp;GitHub</a>
-        </div>
-    </div>
+
     <div class="card mb-4">
         <div class="card-content">
             <div class="content">
@@ -57,6 +74,21 @@
             <a href="https://github.com/django/channels" class="card-footer-item"><i class="fab fa-github"></i>&ensp;GitHub</a>
         </div>
     </div>
+
+    <div class="card mb-4">
+        <div class="card-content">
+            <div class="content">
+                <p class="subtitle">Flask-SocketIO</p>
+                <p class="is-italic">Flask-SocketIO gives Flask applications access to low latency bi-directional communications between the clients and the server.
+                </p>
+            </div>
+        </div>
+        <div class="card-footer">
+            <a href="https://flask-socketio.readthedocs.io/en/latest" class="card-footer-item"><i class="fas fa-book"></i>&ensp;Documentation</a>
+            <a href="https://github.com/miguelgrinberg/flask-socketio" class="card-footer-item"><i class="fab fa-github"></i>&ensp;GitHub</a>
+        </div>
+    </div>
+
     <div class="card mb-4">
         <div class="card-content">
             <div class="content">
@@ -70,32 +102,6 @@
         <div class="card-footer">
             <a href="https://python-hyper.org/projects/wsproto/en/stable" class="card-footer-item"><i class="fas fa-book"></i>&ensp;Documentation</a>
             <a href="https://github.com/python-hyper/wsproto" class="card-footer-item"><i class="fab fa-github"></i>&ensp;GitHub</a>
-        </div>
-    </div>
-    <div class="card mb-4">
-        <div class="card-content">
-            <div class="content">
-                <p class="subtitle">Starlette</p>
-                <p class="is-italic">Starlette is a lightweight ASGI framework/toolkit, which is ideal for building async web services in Python.
-                </p>
-            </div>
-        </div>
-        <div class="card-footer">
-            <a href="https://www.starlette.io/websockets" class="card-footer-item"><i class="fas fa-book"></i>&ensp;Documentation</a>
-            <a href="https://github.com/encode/starlette" class="card-footer-item"><i class="fab fa-github"></i>&ensp;GitHub</a>
-        </div>
-    </div>
-    <div class="card mb">
-        <div class="card-content">
-            <div class="content">
-                <p class="subtitle">FastAPI</p>
-                <p class="is-italic">FastAPI is a modern, fast (high-performance), web framework for building APIs with Python 3.6+ based on standard Python type hints.
-                </p>
-            </div>
-        </div>
-        <div class="card-footer">
-            <a href="https://fastapi.tiangolo.com/advanced/websockets" class="card-footer-item"><i class="fas fa-book"></i>&ensp;Documentation</a>
-            <a href="https://github.com/tiangolo/fastapi" class="card-footer-item"><i class="fab fa-github"></i>&ensp;GitHub</a>
         </div>
     </div>
 

--- a/pydis_site/templates/events/pages/code-jams/9/frameworks.html
+++ b/pydis_site/templates/events/pages/code-jams/9/frameworks.html
@@ -62,7 +62,7 @@
         <div class="card-content">
             <div class="content">
                 <p class="subtitle">Django Channels</p>
-                <>Django Channels adds WebSocket-support to Django - built on ASGI like other web frameworks.
+                <p>Django Channels adds WebSocket-support to Django - built on ASGI like other web frameworks.
                 </p>
             </div>
         </div>

--- a/pydis_site/templates/events/pages/code-jams/9/frameworks.html
+++ b/pydis_site/templates/events/pages/code-jams/9/frameworks.html
@@ -94,7 +94,7 @@
             </div>
         </div>
         <div class="card-footer">
-            <a href="https://asgi.readthedocs.io/en/latest/" class="card-fotter-item"><i class="fa-clipboard-list"></i>Specification</a>
+            <a href="https://asgi.readthedocs.io/en/latest/" class="card-fotter-item"><i class="fas fa-clipboard-list"></i>&ensp;Specification</a>
         </div>
     </div>
 

--- a/pydis_site/templates/events/pages/code-jams/9/frameworks.html
+++ b/pydis_site/templates/events/pages/code-jams/9/frameworks.html
@@ -90,6 +90,14 @@
     <div class="card mb-4">
         <div class="card-content">
             <div class="content">
+                <p class="subtitle">ASGI</p>
+                <p class="is-italic">ASGI is the specification your favourite frameworks are built on. This is not a framework in of itself, but listed here for completeness.</p>
+            </div>
+        </div>
+
+    <div class="card mb-4">
+        <div class="card-content">
+            <div class="content">
                 <p class="subtitle">wsproto</p>
                 <p class="is-italic">wsproto is a pure-Python WebSocket protocol stack written to be as flexible as possible by having the user build the bridge to the I/O.
                 </p>

--- a/pydis_site/templates/events/pages/code-jams/9/frameworks.html
+++ b/pydis_site/templates/events/pages/code-jams/9/frameworks.html
@@ -17,6 +17,16 @@
         If there is a library not listed below that you think should be here, you're welcome to discuss it with the Events Team over at <a href="https://discord.gg/HnGd3znxhJ">the server</a>.
     </p>
 
+    <div class="notification is-info is-light">
+        <p>Most of the below frameworks implement what is called the ASGI Specification.
+            This specification documents how the frameworks should interact with ASGI servers and call the frameworks.
+            You are also allowed to <strong>work with the ASGI specification directly</strong> without a framework, if your team so chooses to.
+            Refer to the <a href="https://asgi.readthedocs.io/en/latest/">specification online</a>.
+        </p>
+    </div>
+
+    <h3 id="approved-frameworks"><a href="#approved-frameworks">Approved Frameworks</a></h3>
+
     <div class="card mb-4">
         <div class="card-content">
             <div class="content">
@@ -83,18 +93,6 @@
         <div class="card-footer">
             <a href="https://flask-socketio.readthedocs.io/en/latest" class="card-footer-item"><i class="fas fa-book"></i>&ensp;Documentation</a>
             <a href="https://github.com/miguelgrinberg/flask-socketio" class="card-footer-item"><i class="fab fa-github"></i>&ensp;GitHub</a>
-        </div>
-    </div>
-
-    <div class="card mb-4">
-        <div class="card-content">
-            <div class="content">
-                <p class="subtitle">ASGI</p>
-                <p>ASGI is the specification your favourite frameworks are built on. This is not a framework in of itself, but listed here for completeness.</p>
-            </div>
-        </div>
-        <div class="card-footer">
-            <a href="https://asgi.readthedocs.io/en/latest/" class="card-footer-item"><i class="fas fa-clipboard-list"></i>&ensp;Specification</a>
         </div>
     </div>
 

--- a/pydis_site/templates/events/pages/code-jams/9/frameworks.html
+++ b/pydis_site/templates/events/pages/code-jams/9/frameworks.html
@@ -19,7 +19,7 @@
 
     <div class="notification is-info is-light">
         <p>Most of the below frameworks implement what is called the ASGI Specification.
-            This specification documents how the frameworks should interact with ASGI servers and call the frameworks.
+            This specification documents how the frameworks should interact with ASGI servers.
             You are also allowed to <strong>work with the ASGI specification directly</strong> without a framework, if your team so chooses to.
             Refer to the <a href="https://asgi.readthedocs.io/en/latest/">specification online</a>.
         </p>


### PR DESCRIPTION
This PR, simply put, reorders the CJ9 frameworks to be in a more familiar order based on recommendation:
- FastAPI and Starlette are both ASGI frameworks many should have heard of
- websockets is the only client library on the list
- Django channels is kept on the list but I did not purposefully give it a different position
- wsproto should be last, only for those who wish to use it

Additionally, the descriptions have been reworded to shine more light on the differences between the frameworks and their websocket aspect of it.

*Flask-socketIO is currently up for discussion so I have not touched it.*