### PR TITLE
Sprinkle back in some CJ9 links

### DIFF
--- a/pydis_site/templates/events/index.html
+++ b/pydis_site/templates/events/index.html
@@ -9,6 +9,9 @@
 {% block event_content %}
     <div class="box">
         <h2 class="title is-4"><a href="{% url "events:page" path="code-jams" %}">Code Jams</a></h2>
+        <div class="notification is-success">
+            <a href="{% url "events:page" path="code-jams/9" %}">The <b>2022 Summer Code Jam</b> is underway!</a>.
+          </div>
         <p>Every year we hold a community-wide Summer Code Jam. For this event, members of our community are assigned to teams to collaborate and create something amazing using a technology we picked for them. One such technology that was picked for the Summer 2021 Code Jam was text user interfaces (TUIs), where teams could pick from a pre-approved list of frameworks.</p>
         <p>To help fuel the creative process, we provide a specific theme, like <strong>Think Inside the Box</strong> or <strong>Early Internet</strong>. At the end of the Code Jam, the projects are judged by Python Discord server staff members and guest judges from the larger Python community. The judges will consider creativity, code quality, teamwork, and adherence to the theme.</p>
         <p>If you want to read more about Code Jams, visit our <a href="{% url "events:page" path="code-jams" %}">Code Jam info page</a> or watch this video showcasing the best projects created during the <strong>Winter Code Jam 2020: Ancient Technology</strong>:</p>

--- a/pydis_site/templates/events/sidebar/code-jams/previous-code-jams.html
+++ b/pydis_site/templates/events/sidebar/code-jams/previous-code-jams.html
@@ -1,6 +1,7 @@
 <div class="box">
     <p class="menu-label">Previous Code Jams</p>
     <ul class="menu-list">
+        <li><a class="has-text-link" href="{% url "events:page" path="code-jams/9" %}">Code Jam 9: (Theme to be announced)</a></li>
         <li><a class="has-text-link" href="{% url "events:page" path="code-jams/8" %}">Code Jam 8: Think Inside the Box</a></li>
         <li><a class="has-text-link" href="{% url "events:page" path="code-jams/7" %}">Code Jam 7: Early Internet</a></li>
         <li><a class="has-text-link" href="{% url "events:page" path="code-jams/6" %}">Code Jam 6: Ancient Technology</a></li>


### PR DESCRIPTION
So, I always navigate to the events page and somehow miss the huge summer code jam duck banner on the index page.

I was missing the big green box linking to CJ9 on the Events page and I think we should keep this here for the duration of the event. Let's not make users hunt for content.

<img width="941" alt="image" src="https://user-images.githubusercontent.com/75038675/179669441-d7634262-2027-445a-9824-2aa459d7bf1c.png">

To that end I've also added a CJ9 link on the CJ Info page, which can be updated once the theme is finalized and announced. (I know it's not a "previous" jam yet but soon enough, it will be)

<img width="446" alt="image" src="https://user-images.githubusercontent.com/75038675/179669390-384a6d47-c5b2-4f05-bca4-4e292a62aa7a.png">
