### PR TITLE
Clarify WebSocket restriction rule's impact on static serving

### DIFF
--- a/pydis_site/templates/events/pages/code-jams/9/_index.html
+++ b/pydis_site/templates/events/pages/code-jams/9/_index.html
@@ -26,7 +26,7 @@
         <li><strike>Wednesday, June 29 - The Qualifier is released</strike></li>
         <li><strike>Wednesday, July 6 - Voting for the theme opens</strike></li>
         <li><strike>Wednesday, July 13 - The Qualifier closes</strike></li>
-        <li>Thursday, July 21 - Code Jam Begins</li>
+        <li><strike>Thursday, July 21 - Code Jam Begins</strike></li>
         <li>Sunday, July 31 - Coding portion of the jam ends</li>
         <li>Sunday, August 4 - Code Jam submissions are closed</li>
     </ul>

--- a/pydis_site/templates/events/pages/code-jams/9/rules.html
+++ b/pydis_site/templates/events/pages/code-jams/9/rules.html
@@ -17,9 +17,11 @@
 
         <p>
             An exception to this rule is that communication with databases and files is allowed for accessing resources or for storage purposes.
-            For example, you may use PostgreSQL as a database but not its `NOTIFY` command.
+            For example, you may use PostgreSQL as a database but not its <code>NOTIFY</code> command.
             Working with subprocesses (through stdin/stdout or <code>multiprocessing.Pool()</code>/<code>concurrent.futures.ProcessPoolExecutor()</code>) is also allowed.
         </p>
+
+        <p>Another exception is made for serving static files, which normally uses HTTP. You are also allowed to serve a JavaScript-implemented client for your WebSocket server.</p>
 
         <p>If you're interested in utilizing a particular non-WebSocket method of communication, reach out to the Events Team for discussion and approval</p>
     </li>

--- a/pydis_site/templates/events/pages/code-jams/9/rules.html
+++ b/pydis_site/templates/events/pages/code-jams/9/rules.html
@@ -21,7 +21,7 @@
             Working with subprocesses (through stdin/stdout or <code>multiprocessing.Pool()</code>/<code>concurrent.futures.ProcessPoolExecutor()</code>) is also allowed.
         </p>
 
-        <p>Another exception is made for serving static files, which normally uses HTTP. You are also allowed to serve a JavaScript-implemented client for your WebSocket server.</p>
+        <p>Another exception is made for serving static files, which normally uses HTTP. You are allowed to serve a JavaScript-implemented client for your WebSocket server.</p>
 
         <p>If you're interested in utilizing a particular non-WebSocket method of communication, reach out to the Events Team for discussion and approval</p>
     </li>

--- a/pydis_site/templates/events/sidebar/code-jams/previous-code-jams.html
+++ b/pydis_site/templates/events/sidebar/code-jams/previous-code-jams.html
@@ -1,7 +1,7 @@
 <div class="box">
     <p class="menu-label">Previous Code Jams</p>
     <ul class="menu-list">
-        <li><a class="has-text-link" href="{% url "events:page" path="code-jams/9" %}">Code Jam 9: (Theme to be announced)</a></li>
+        <li><a class="has-text-link" href="{% url "events:page" path="code-jams/9" %}">Code Jam 9: It's Not A Bug, It's A Feature</a></li>
         <li><a class="has-text-link" href="{% url "events:page" path="code-jams/8" %}">Code Jam 8: Think Inside the Box</a></li>
         <li><a class="has-text-link" href="{% url "events:page" path="code-jams/7" %}">Code Jam 7: Early Internet</a></li>
         <li><a class="has-text-link" href="{% url "events:page" path="code-jams/6" %}">Code Jam 6: Ancient Technology</a></li>


### PR DESCRIPTION
Before this change, the rule technically disallowed implementing JavaScript clients because webbrowsers use HTTP to fetch the static files.

Originally brought up in one of the code jam team channels.

---

*This PR also fixes a mistake in a previous commit where Markdown-style characters were used instead of code-tags.*
