### PR TITLE
Static Builds Small Improvements

### DIFF
--- a/pydis_site/apps/api/github_utils.py
+++ b/pydis_site/apps/api/github_utils.py
@@ -9,7 +9,7 @@ import jwt
 
 from pydis_site import settings
 
-MAX_RUN_TIME = datetime.timedelta(minutes=3)
+MAX_RUN_TIME = datetime.timedelta(minutes=10)
 """The maximum time allowed before an action is declared timed out."""
 ISO_FORMAT_STRING = "%Y-%m-%dT%H:%M:%SZ"
 """The datetime string format GitHub uses."""

--- a/static-builds/netlify_build.py
+++ b/static-builds/netlify_build.py
@@ -15,6 +15,18 @@ from urllib import parse
 
 import httpx
 
+
+def raise_response(response: httpx.Response) -> None:
+    """Raise an exception from a response if necessary."""
+    if response.status_code // 100 != 2:
+        try:
+            print(response.json())
+        except json.JSONDecodeError:
+            pass
+
+    response.raise_for_status()
+
+
 if __name__ == "__main__":
     owner, repo = parse.urlparse(os.getenv("REPOSITORY_URL")).path.lstrip("/").split("/")[0:2]
 
@@ -29,14 +41,7 @@ if __name__ == "__main__":
     ])
     print(f"Fetching download URL from {download_url}")
     response = httpx.get(download_url, follow_redirects=True)
-
-    if response.status_code // 100 != 2:
-        try:
-            print(response.json())
-        except json.JSONDecodeError:
-            pass
-
-        response.raise_for_status()
+    raise_response(response)
 
     # The workflow is still pending, retry in a bit
     while response.status_code == 202:
@@ -44,6 +49,7 @@ if __name__ == "__main__":
         time.sleep(10)
         response = httpx.get(download_url, follow_redirects=True)
 
+    raise_response(response)
     url = response.json()["url"]
     print(f"Downloading build from {url}")
     zipped_content = httpx.get(url, follow_redirects=True)

--- a/static-builds/netlify_build.py
+++ b/static-builds/netlify_build.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     raise_response(response)
     url = response.json()["url"]
     print(f"Downloading build from {url}")
-    zipped_content = httpx.get(url, follow_redirects=True)
+    zipped_content = httpx.get(url, follow_redirects=True, timeout=3 * 60)
     zipped_content.raise_for_status()
 
     zip_file = Path("temp.zip")


### PR DESCRIPTION
This includes a few small bugfixes and improvements to #742. The first bugfix is for scenarios where the build action bypasses the maximum deadline specified by the API. This PR adds the missing raise_for_status which should display a better error message in that scenario. This PR also increases the timeout when downloading artifacts, since in the case of botcore it can go to ~100MB. The deadline for the API is also increased since bot-core can take upwards of 7 minutes in worst case scenarios.