### PR TITLE
Fix Warnings & Enable In Tests

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -103,6 +103,7 @@ jobs:
           CI: True
           DATABASE_URL: postgres://pysite:pysite@localhost:7777/pysite
           METRICITY_DB_URL: postgres://pysite:pysite@localhost:7777/metricity
+          PYTHONWARNINGS: error
 
       # This step will publish the coverage reports coveralls.io and
       # print a "job" link in the output of the GitHub Action

--- a/manage.py
+++ b/manage.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import django
 from django.contrib.auth import get_user_model
 from django.core.management import call_command, execute_from_command_line
+from django.test.utils import ignore_warnings
 
 DEFAULT_ENVS = {
     "DJANGO_SETTINGS_MODULE": "pydis_site.settings",
@@ -154,7 +155,16 @@ class SiteManager:
     def run_tests(self) -> None:
         """Prepare and run the test suite."""
         self.prepare_environment()
-        call_command(*sys.argv[1:])
+        # The whitenoise package expects a staticfiles directory to exist during startup,
+        # else it raises a warning. This is fine under normal application, but during
+        # tests, staticfiles are not, and do not need to be generated.
+        # The following line suppresses the warning.
+        # Reference: https://github.com/evansd/whitenoise/issues/215
+        with ignore_warnings(
+            message=r"No directory at: .*staticfiles",
+            module="whitenoise.base",
+        ):
+            call_command(*sys.argv[1:])
 
 
 def clean_up_static_files(build_folder: Path) -> None:

--- a/pydis_site/apps/api/__init__.py
+++ b/pydis_site/apps/api/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'pydis_site.apps.api.apps.ApiConfig'

--- a/pydis_site/apps/api/tests/test_filterlists.py
+++ b/pydis_site/apps/api/tests/test_filterlists.py
@@ -64,8 +64,8 @@ class FetchTests(AuthenticatedAPITestCase):
 
         self.assertEqual(response.status_code, 200)
         for api_type, model_type in zip(response.json(), FilterList.FilterListType.choices):
-            self.assertEquals(api_type[0], model_type[0])
-            self.assertEquals(api_type[1], model_type[1])
+            self.assertEqual(api_type[0], model_type[0])
+            self.assertEqual(api_type[1], model_type[1])
 
 
 class CreationTests(AuthenticatedAPITestCase):

--- a/pydis_site/apps/api/viewsets/bot/aoc_completionist_block.py
+++ b/pydis_site/apps/api/viewsets/bot/aoc_completionist_block.py
@@ -70,4 +70,4 @@ class AocCompletionistBlockViewSet(
     serializer_class = AocCompletionistBlockSerializer
     queryset = AocCompletionistBlock.objects.all()
     filter_backends = (DjangoFilterBackend,)
-    filter_fields = ("user__id", "is_blocked")
+    filterset_fields = ("user__id", "is_blocked")

--- a/pydis_site/apps/api/viewsets/bot/aoc_link.py
+++ b/pydis_site/apps/api/viewsets/bot/aoc_link.py
@@ -68,4 +68,4 @@ class AocAccountLinkViewSet(
     serializer_class = AocAccountLinkSerializer
     queryset = AocAccountLink.objects.all()
     filter_backends = (DjangoFilterBackend,)
-    filter_fields = ("user__id", "aoc_username")
+    filterset_fields = ("user__id", "aoc_username")

--- a/pydis_site/apps/api/viewsets/bot/infraction.py
+++ b/pydis_site/apps/api/viewsets/bot/infraction.py
@@ -154,7 +154,7 @@ class InfractionViewSet(
     queryset = Infraction.objects.all()
     pagination_class = LimitOffsetPaginationExtended
     filter_backends = (DjangoFilterBackend, SearchFilter, OrderingFilter)
-    filter_fields = ('user__id', 'actor__id', 'active', 'hidden', 'type')
+    filterset_fields = ('user__id', 'actor__id', 'active', 'hidden', 'type')
     search_fields = ('$reason',)
     frozen_fields = ('id', 'inserted_at', 'type', 'user', 'actor', 'hidden')
 

--- a/pydis_site/apps/api/viewsets/bot/nomination.py
+++ b/pydis_site/apps/api/viewsets/bot/nomination.py
@@ -172,7 +172,7 @@ class NominationViewSet(CreateModelMixin, RetrieveModelMixin, ListModelMixin, Ge
     serializer_class = NominationSerializer
     queryset = Nomination.objects.all()
     filter_backends = (DjangoFilterBackend, SearchFilter, OrderingFilter)
-    filter_fields = ('user__id', 'active')
+    filterset_fields = ('user__id', 'active')
     frozen_fields = ('id', 'inserted_at', 'user', 'ended_at')
     frozen_on_create = ('ended_at', 'end_reason', 'active', 'inserted_at', 'reviewed')
 

--- a/pydis_site/apps/api/viewsets/bot/reminder.py
+++ b/pydis_site/apps/api/viewsets/bot/reminder.py
@@ -125,4 +125,4 @@ class ReminderViewSet(
     serializer_class = ReminderSerializer
     queryset = Reminder.objects.prefetch_related('author')
     filter_backends = (DjangoFilterBackend, SearchFilter)
-    filter_fields = ('active', 'author__id')
+    filterset_fields = ('active', 'author__id')

--- a/pydis_site/apps/api/viewsets/bot/user.py
+++ b/pydis_site/apps/api/viewsets/bot/user.py
@@ -237,7 +237,7 @@ class UserViewSet(ModelViewSet):
     queryset = User.objects.all().order_by("id")
     pagination_class = UserListPagination
     filter_backends = (DjangoFilterBackend,)
-    filter_fields = ('name', 'discriminator')
+    filterset_fields = ('name', 'discriminator')
 
     def get_serializer(self, *args, **kwargs) -> ModelSerializer:
         """Set Serializer many attribute to True if request body contains a list."""

--- a/pydis_site/apps/content/tests/test_views.py
+++ b/pydis_site/apps/content/tests/test_views.py
@@ -172,7 +172,7 @@ class PageOrCategoryViewTests(MockPagesTestCase, SimpleTestCase, TestCase):
         for item in context["breadcrumb_items"]:
             item["path"] = Path(item["path"])
 
-        self.assertEquals(
+        self.assertEqual(
             context["breadcrumb_items"],
             [
                 {"name": PARSED_CATEGORY_INFO["title"], "path": Path(".")},

--- a/pydis_site/apps/home/tests/test_repodata_helpers.py
+++ b/pydis_site/apps/home/tests/test_repodata_helpers.py
@@ -42,7 +42,7 @@ class TestRepositoryMetadataHelpers(TestCase):
         metadata = self.home_view._get_repo_data()
 
         self.assertIsInstance(metadata[0], RepositoryMetadata)
-        self.assertEquals(len(metadata), len(self.home_view.repos))
+        self.assertEqual(len(metadata), len(self.home_view.repos))
 
     def test_returns_cached_metadata(self):
         """Test if the _get_repo_data helper returns cached data when available."""
@@ -82,7 +82,7 @@ class TestRepositoryMetadataHelpers(TestCase):
         repo = self.home_view.repos[0]
 
         self.assertIsInstance(api_data, dict)
-        self.assertEquals(len(api_data), len(self.home_view.repos))
+        self.assertEqual(len(api_data), len(self.home_view.repos))
         self.assertIn(repo, api_data.keys())
         self.assertIn("stargazers_count", api_data[repo])
 
@@ -126,7 +126,7 @@ class TestRepositoryMetadataHelpers(TestCase):
         with self.assertLogs():
             metadata = self.home_view._get_repo_data()
 
-        self.assertEquals(len(metadata), 0)
+        self.assertEqual(len(metadata), 0)
 
     def test_cleans_up_stale_metadata(self):
         """Tests that we clean up stale metadata when we start the HomeView."""

--- a/pydis_site/settings.py
+++ b/pydis_site/settings.py
@@ -200,7 +200,6 @@ AUTH_PASSWORD_VALIDATORS = [
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 USE_I18N = True
-USE_L10N = True
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
While working on upgrading some of our dependencies, I started running into issues due to us continuing to use deprecated features. This includes:
- django-filter. The history behind django-filter, and our usage off it is a little complicated. I tried to summarize in 6fe491c, but I can elaborate/explain further if needed. The warnings go from deprecations to removal in the current latest version, which is where I ran into issues.
- Django 5.x: django actually emits a helpful deprecation warning for features that are removed in 5.x. There are a few that have been added since the initial upgrade, so those were updated here. They are very simple things
- Unittest's `assertEquals` has been deprecated since 3.2, in favor of `assertEqual`.

With these changes made, there were no other warnings remaining, so I took the liberty of enabling warnings in CI, as a relatively harmless method of detecting some of these things earlier.