### PR TITLE
Add a collection of keywords per rule

### DIFF
--- a/pydis_site/apps/api/views.py
+++ b/pydis_site/apps/api/views.py
@@ -124,35 +124,44 @@ class RulesView(APIView):
 
         return Response([
             (
-                f"Follow the {pydis_coc}."
+                f"Follow the {pydis_coc}.",
+                {"coc", "conduct", "code"}
             ),
             (
-                f"Follow the {discord_community_guidelines} and {discord_tos}."
+                f"Follow the {discord_community_guidelines} and {discord_tos}.",
+                {"guidelines", "discord_tos"}
             ),
             (
-                "Respect staff members and listen to their instructions."
+                "Respect staff members and listen to their instructions.",
+                {"staff", "instructions"}
             ),
             (
                 "Use English to the best of your ability. "
-                "Be polite if someone speaks English imperfectly."
+                "Be polite if someone speaks English imperfectly.",
+                {"english", "language"}
             ),
             (
                 "Do not provide or request help on projects that may break laws, "
-                "breach terms of services, or are malicious or inappropriate."
+                "breach terms of services, or are malicious or inappropriate.",
+                {"infraction", "tos", "breach", "malicious", "inappropriate"}
             ),
             (
-                "Do not post unapproved advertising."
+                "Do not post unapproved advertising.",
+                {"ads", "advertising"}
             ),
             (
                 "Keep discussions relevant to the channel topic. "
-                "Each channel's description tells you the topic."
+                "Each channel's description tells you the topic.",
+                {"off-topic", "topic", "relevance"}
             ),
             (
                 "Do not help with ongoing exams. When helping with homework, "
-                "help people learn how to do the assignment without doing it for them."
+                "help people learn how to do the assignment without doing it for them.",
+                {"exams", "assignment", "assignments", "homework"}
             ),
             (
-                "Do not offer or ask for paid work of any kind."
+                "Do not offer or ask for paid work of any kind.",
+                {"work", "money"}
             ),
         ])
 

--- a/pydis_site/apps/api/views.py
+++ b/pydis_site/apps/api/views.py
@@ -100,7 +100,12 @@ class RulesView(APIView):
 
     # `format` here is the result format, we have a link format here instead.
     def get(self, request, format=None):  # noqa: D102,ANN001,ANN201
-        """Returns a list of our community rules coupled with their keywords."""
+        """
+        Returns a list of our community rules coupled with their keywords.
+
+        Each item in the returned list is a tuple with the rule as first item
+        and a list of keywords that match that rules as second item.
+        """
         link_format = request.query_params.get('link_format', 'md')
         if link_format not in ('html', 'md'):
             raise ParseError(

--- a/pydis_site/apps/api/views.py
+++ b/pydis_site/apps/api/views.py
@@ -100,6 +100,7 @@ class RulesView(APIView):
 
     # `format` here is the result format, we have a link format here instead.
     def get(self, request, format=None):  # noqa: D102,ANN001,ANN201
+        """Returns a list of our community rules coupled with their keywords."""
         link_format = request.query_params.get('link_format', 'md')
         if link_format not in ('html', 'md'):
             raise ParseError(

--- a/pydis_site/apps/api/views.py
+++ b/pydis_site/apps/api/views.py
@@ -126,43 +126,43 @@ class RulesView(APIView):
         return Response([
             (
                 f"Follow the {pydis_coc}.",
-                {"coc", "conduct", "code"}
+                ["coc", "conduct", "code"]
             ),
             (
                 f"Follow the {discord_community_guidelines} and {discord_tos}.",
-                {"guidelines", "discord_tos"}
+                ["discord", "guidelines", "discord_tos"]
             ),
             (
                 "Respect staff members and listen to their instructions.",
-                {"staff", "instructions"}
+                ["respect", "staff", "instructions"]
             ),
             (
                 "Use English to the best of your ability. "
                 "Be polite if someone speaks English imperfectly.",
-                {"english", "language"}
+                ["english", "language"]
             ),
             (
                 "Do not provide or request help on projects that may break laws, "
                 "breach terms of services, or are malicious or inappropriate.",
-                {"infraction", "tos", "breach", "malicious", "inappropriate"}
+                ["infraction", "tos", "breach", "malicious", "inappropriate"]
             ),
             (
                 "Do not post unapproved advertising.",
-                {"ads", "advertising"}
+                ["ad", "ads", "advert", "advertising"]
             ),
             (
                 "Keep discussions relevant to the channel topic. "
                 "Each channel's description tells you the topic.",
-                {"off-topic", "topic", "relevance"}
+                ["off-topic", "topic", "relevance"]
             ),
             (
                 "Do not help with ongoing exams. When helping with homework, "
                 "help people learn how to do the assignment without doing it for them.",
-                {"exams", "assignment", "assignments", "homework"}
+                ["exam", "exams", "assignment", "assignments", "homework"]
             ),
             (
                 "Do not offer or ask for paid work of any kind.",
-                {"work", "money"}
+                ["paid", "work", "money"]
             ),
         ])
 

--- a/pydis_site/apps/api/views.py
+++ b/pydis_site/apps/api/views.py
@@ -42,9 +42,9 @@ class RulesView(APIView):
     Example response:
 
     >>> [
-    ...     ("Eat candy.", ["candy", "sweets"]),
-    ...     ("Wake up at 4 AM.", ["wake_up", "early", "early_bird"]),
-    ...     ("Take your medicine.", ["medicine", "health"])
+    ...     ["Eat candy.", ["candy", "sweets"]],
+    ...     ["Wake up at 4 AM.", ["wake_up", "early", "early_bird"]],
+    ...     ["Take your medicine.", ["medicine", "health"]]
     ... ]
 
     Since some of the the rules require links, this view

--- a/pydis_site/apps/api/views.py
+++ b/pydis_site/apps/api/views.py
@@ -37,12 +37,15 @@ class RulesView(APIView):
 
     ## Routes
     ### GET /rules
-    Returns a JSON array containing the server's rules:
+    Returns a JSON array containing the server's rules
+    coupled with a list of keywords that will be used
+    when searching for particular rules upon using the
+    bot's `!rule` command
 
     >>> [
-    ...     "Eat candy.",
-    ...     "Wake up at 4 AM.",
-    ...     "Take your medicine."
+    ...     ("Eat candy.", ["candy", "sweet"]),
+    ...     ("Wake up at 4 AM.", ["wake_up", "early", "early_bird"]),
+    ...     ("Take your medicine.", ["medicine", "health"])
     ... ]
 
     Since some of the the rules require links, this view

--- a/pydis_site/apps/api/views.py
+++ b/pydis_site/apps/api/views.py
@@ -38,9 +38,8 @@ class RulesView(APIView):
     ## Routes
     ### GET /rules
     Returns a JSON array containing the server's rules
-    coupled with a list of keywords that will be used
-    when searching for particular rules upon using the
-    bot's `!rule` command
+    and keywords relating to each rule.
+    Example response:
 
     >>> [
     ...     ("Eat candy.", ["candy", "sweets"]),

--- a/pydis_site/apps/api/views.py
+++ b/pydis_site/apps/api/views.py
@@ -43,7 +43,7 @@ class RulesView(APIView):
     bot's `!rule` command
 
     >>> [
-    ...     ("Eat candy.", ["candy", "sweet"]),
+    ...     ("Eat candy.", ["candy", "sweets"]),
     ...     ("Wake up at 4 AM.", ["wake_up", "early", "early_bird"]),
     ...     ("Take your medicine.", ["medicine", "health"])
     ... ]


### PR DESCRIPTION
⚠️  Note to core devs: This must be merged with https://github.com/python-discord/bot/pull/2261⚠️ 

In reference to [this](https://github.com/python-discord/bot/issues/2108) issue, this commit aims to add an initial set of keywords per rule.

These keywords will be later used in the "rule" bot command in order to make rule identification easier