### PR TITLE
Fix Poetry 1.2 Support & Lock Poetry Version

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -10,76 +10,26 @@ on:
 jobs:
   lint-test:
     runs-on: ubuntu-latest
-    env:
-      # Configure pip to cache dependencies and do a user install
-      PIP_NO_CACHE_DIR: false
-      PIP_USER: 1
-
-      # Make sure package manager does not use virtualenv
-      POETRY_VIRTUALENVS_CREATE: false
-
-      # Specify explicit paths for python dependencies and the pre-commit
-      # environment so we know which directories to cache
-      POETRY_CACHE_DIR: ${{ github.workspace }}/.cache/py-user-base
-      PYTHONUSERBASE: ${{ github.workspace }}/.cache/py-user-base
-      PRE_COMMIT_HOME: ${{ github.workspace }}/.cache/pre-commit-cache
 
     steps:
-      - name: Add custom PYTHONUSERBASE to PATH
-        run: echo '${{ env.PYTHONUSERBASE }}/bin/' >> $GITHUB_PATH
-
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Setup python
-        id: python
-        uses: actions/setup-python@v2
+      - name: Install Python Dependencies
+        uses: HassanAbouelela/actions/setup-python@setup-python_v1.3.1
         with:
-          python-version: '3.9'
+          dev: true
+          python_version: '3.9'
 
       # Start the database early to give it a chance to get ready before
       # we start running tests.
       - name: Run database using docker-compose
         run: docker-compose run -d -p 7777:5432 --name pydis_web postgres
 
-      # This step caches our Python dependencies. To make sure we
-      # only restore a cache when the dependencies, the python version,
-      # the runner operating system, and the dependency location haven't
-      # changed, we create a cache key that is a composite of those states.
-      #
-      # Only when the context is exactly the same, we will restore the cache.
-      - name: Python Dependency Caching
-        uses: actions/cache@v2
-        id: python_cache
-        with:
-          path: ${{ env.PYTHONUSERBASE }}
-          key: "python-0-${{ runner.os }}-${{ env.PYTHONUSERBASE }}-\
-          ${{ steps.python.outputs.python-version }}-\
-          ${{ hashFiles('./pyproject.toml', './poetry.lock') }}"
-
-      # Install our dependencies if we did not restore a dependency cache
-      - name: Install dependencies using poetry
-        if: steps.python_cache.outputs.cache-hit != 'true'
-        run: |
-          pip install poetry
-          poetry install
-
-      # This step caches our pre-commit environment. To make sure we
-      # do create a new environment when our pre-commit setup changes,
-      # we create a cache key based on relevant factors.
-      - name: Pre-commit Environment Caching
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.PRE_COMMIT_HOME }}
-          key: "precommit-0-${{ runner.os }}-${{ env.PRE_COMMIT_HOME }}-\
-          ${{ steps.python.outputs.python-version }}-\
-          ${{ hashFiles('./.pre-commit-config.yaml') }}"
-
       # We will not run `flake8` here, as we will use a separate flake8
-      # action. As pre-commit does not support user installs, we set
-      # PIP_USER=0 to not do a user install.
+      # action.
       - name: Run pre-commit hooks
-        run: export PIP_USER=0; SKIP=flake8 pre-commit run --all-files
+        run: SKIP=flake8 pre-commit run --all-files
 
       # Run flake8 and have it format the linting errors in the format of
       # the GitHub Workflow command to register error annotations. This

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,14 @@
-FROM --platform=linux/amd64 python:3.9-slim-buster
+FROM ghcr.io/chrislovering/python-poetry-base:3.9-slim
 
 # Allow service to handle stops gracefully
 STOPSIGNAL SIGQUIT
-
-# Set pip to have cleaner logs and no saved cache
-ENV PIP_NO_CACHE_DIR=false \
-    POETRY_VIRTUALENVS_CREATE=false
-
-# Install poetry
-RUN pip install -U poetry
 
 # Copy the project files into working directory
 WORKDIR /app
 
 # Install project dependencies
 COPY pyproject.toml poetry.lock ./
-RUN poetry install --no-dev
+RUN poetry install --without dev
 
 # Set Git SHA environment variable
 ARG git_sha="development"
@@ -34,14 +27,14 @@ RUN \
     SECRET_KEY=dummy_value \
     DATABASE_URL=postgres://localhost \
     METRICITY_DB_URL=postgres://localhost \
-    python manage.py collectstatic --noinput --clear
+    poetry run python manage.py collectstatic --noinput --clear
 
 # Build static files if we are doing a static build
 ARG STATIC_BUILD=false
 RUN if [ $STATIC_BUILD = "TRUE" ] ; \
-  then SECRET_KEY=dummy_value python manage.py distill-local build --traceback --force ; \
+  then SECRET_KEY=dummy_value poetry run python manage.py distill-local build --traceback --force ; \
 fi
 
 # Run web server through custom manager
-ENTRYPOINT ["python", "manage.py"]
+ENTRYPOINT ["poetry", "run", "python", "manage.py"]
 CMD ["run"]


### PR DESCRIPTION
Poetry 1.2 introduced a regression which broke pip `--user` installs. These types of install where the main way we did installations in docker and CI, which made it much more convenient to control their location, availability, and caching.

Poetry's team does not recognize this as a supported use case, so major changes were required to get everything working again. To prevent future uncontrolled failures such as this, the poetry version has been locked.

This is a distilled version of https://github.com/python-discord/bot/pull/2268/ and the subsequent https://github.com/python-discord/bot/pull/2276/, please expedite approval.