### PR TITLE
`REPO_TOKEN` is no more.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: python-discord/kubernetes
-          token: ${{ secrets.REPO_TOKEN }}
 
       - name: Authenticate with Kubernetes
         uses: azure/k8s-set-context@v1


### PR DESCRIPTION
Solves part of https://github.com/python-discord/kubernetes/issues/140, since the repository is now public.