### PR TITLE
Stop using deprecated set-output command in actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
         id: sha_tag
         run: |
           tag=$(cut -c 1-7 <<< $GITHUB_SHA)
-          echo "::set-output name=tag::$tag"
+          echo "tag=$tag" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      # The current version (v2) of Docker's build-push action uses
+      # The current version (v3) of Docker's build-push action uses
       # buildx, which comes with BuildKit features that help us speed
       # up our builds using additional cache features. Buildx also
       # has a lot of other features that are not as relevant to us.

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,7 +20,7 @@ jobs:
         id: sha_tag
         run: |
           tag=$(cut -c 1-7 <<< $GITHUB_SHA)
-          echo "::set-output name=tag::$tag"
+          echo "tag=$tag" >> $GITHUB_OUTPUT
 
       # Check out the private Kubernetes repository for the
       # deployment.yaml file using a GitHub Personal Access

--- a/.github/workflows/static-preview.yaml
+++ b/.github/workflows/static-preview.yaml
@@ -14,12 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-     # Create a commit SHA-based tag for the container repositories
+      # Create a commit SHA-based tag for the container repositories
       - name: Create SHA Container Tag
         id: sha_tag
         run: |
           tag=$(cut -c 1-7 <<< $GITHUB_SHA)
-          echo "::set-output name=tag::$tag"
+          echo "tag=$tag" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/status_embed.yaml
+++ b/.github/workflows/status_embed.yaml
@@ -44,10 +44,10 @@ jobs:
           wget --quiet --header="Authorization: token $GITHUB_TOKEN" -O pull_request_payload.zip $DOWNLOAD_URL || exit 2
           unzip -p pull_request_payload.zip > pull_request_payload.json
           [ -s pull_request_payload.json ] || exit 3
-          echo "::set-output name=pr_author_login::$(jq -r '.user.login // empty' pull_request_payload.json)"
-          echo "::set-output name=pr_number::$(jq -r '.number // empty' pull_request_payload.json)"
-          echo "::set-output name=pr_title::$(jq -r '.title // empty' pull_request_payload.json)"
-          echo "::set-output name=pr_source::$(jq -r '.head.label // empty' pull_request_payload.json)"
+          echo "pr_author_login=$(jq -r '.user.login // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
+          echo "pr_number=$(jq -r '.number // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
+          echo "pr_title=$(jq -r '.title // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
+          echo "pr_source=$(jq -r '.head.label // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
GitHub has deprecated the old format, so I've updated to use the new syntax:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/