### PR TITLE
fix: use new domain for bot tutorial resource

### DIFF
--- a/pydis_site/apps/content/resources/guides/python-guides/keeping-tokens-safe.md
+++ b/pydis_site/apps/content/resources/guides/python-guides/keeping-tokens-safe.md
@@ -11,7 +11,7 @@ To help prevent leaking your token,
 you should ensure that you don't upload it to an open source program/website,
 such as replit and github, as they show your code publicly.
 The best practice for storing tokens is generally utilising .env files
-([click here](https://vcokltfre.dev/tips/tokens/.) for more information on storing tokens safely).
+([click here](https://tutorial.vco.sh/tips/tokens/) for more information on storing tokens safely).
 
 # What should I do if my token does get leaked?
 

--- a/pydis_site/apps/content/resources/guides/python-guides/why-not-json-as-database.md
+++ b/pydis_site/apps/content/resources/guides/python-guides/why-not-json-as-database.md
@@ -2,7 +2,7 @@
 title: Why JSON is unsuitable as a database
 description: The many reasons why you shouldn't use JSON as a database, and instead opt for SQL.
 relevant_links:
-    Tips on Storing Data: https://tutorial.vcokltfre.dev/tips/storage/
+    Tips on Storing Data: https://tutorial.vco.sh/tips/storage/
 ---
 
 JSON, quite simply, is not a database. It's not designed to be a data storage format,

--- a/pydis_site/apps/resources/resources/vcokltfre_discord_bot_tutorial.yaml
+++ b/pydis_site/apps/resources/resources/vcokltfre_discord_bot_tutorial.yaml
@@ -2,7 +2,7 @@ description: This tutorial, written by vcokltfre,
   will walk you through all the aspects of creating your own Discord bot,
   starting from creating the bot user itself.
 name: vcokltfre's Discord Bot Tutorial
-title_url: https://tutorial.vcokltfre.dev/
+title_url: https://tutorial.vco.sh/
 tags:
   topics:
     - discord bots


### PR DESCRIPTION
Simple as the title says really; this is the domain the tutorial lives at now.