### PR TITLE
Add rule 10 to the list of api rules

### DIFF
--- a/pydis_site/apps/api/views.py
+++ b/pydis_site/apps/api/views.py
@@ -171,6 +171,10 @@ class RulesView(APIView):
                 "Do not offer or ask for paid work of any kind.",
                 ["paid", "work", "money"]
             ),
+            (
+              "Do not copy and paste answers from ChatGPT or similar AI tools.",
+              ["gpt", "chatgpt", "gpt3", "ai"]
+            ),
         ])
 
 


### PR DESCRIPTION
Add our newest 10th rule that dictates usage of chatgpt & other ai tools to the list of api rules used by bot

All keywords are open for discussion