### PR TITLE
Add Python Graph Gallery to the Resources

### DIFF
--- a/pydis_site/apps/resources/resources/python_graph_gallery.yaml
+++ b/pydis_site/apps/resources/resources/python_graph_gallery.yaml
@@ -1,0 +1,17 @@
+description: A collection of hundreds of charts made with Python with their associated reproducible code.
+name: Python Graph Gallery
+title_url: https://www.python-graph-gallery.com/
+urls:
+  - icon: branding/github
+    url: https://github.com/holtzy/The-Python-Graph-Gallery
+    color: black
+tags:
+  topics:
+    - data science
+  payment_tiers:
+    - free
+  difficulty:
+    - beginner
+    - intermediate
+  type:
+    - tutorial


### PR DESCRIPTION
Adds Python Graph Gallery as a new resource. The discussion for this change can be found in the issue that this PR closes.

Closes python-discord/meta#210