### PR TITLE
Make unittests independent of GitHub

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,6 +11,8 @@ omit =
     */apps.py
     */urls.py
     pydis_site/apps/api/models/bot/metricity.py
+    # GitHub API functions are mocked away
+    pydis_site/apps/content/utils.py
     pydis_site/wsgi.py
     pydis_site/settings.py
     pydis_site/utils/resources.py

--- a/pydis_site/apps/content/tests/test_views.py
+++ b/pydis_site/apps/content/tests/test_views.py
@@ -1,6 +1,6 @@
 import textwrap
 from pathlib import Path
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import django.test
 import markdown
@@ -223,7 +223,8 @@ class TagViewTests(django.test.TestCase):
 
     def test_invalid_tag_404(self):
         """Test that a tag which doesn't exist raises a 404."""
-        response = self.client.get("/pages/tags/non-existent/")
+        with mock.patch("pydis_site.apps.content.utils.fetch_tags", autospec=True):
+            response = self.client.get("/pages/tags/non-existent/")
         self.assertEqual(404, response.status_code)
 
     def test_context_tag(self):

--- a/pydis_site/apps/home/tests/test_views.py
+++ b/pydis_site/apps/home/tests/test_views.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.test import TestCase
 from django.urls import reverse
 
@@ -6,5 +8,6 @@ class TestIndexReturns200(TestCase):
     def test_index_returns_200(self):
         """Check that the index page returns a HTTP 200 response."""
         url = reverse('home:home')
-        resp = self.client.get(url)
+        with mock.patch("pydis_site.apps.home.views.HomeView._get_api_data", autospec=True):
+            resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
This fixes a problem where running the unit tests successively a lot would result in 403 ratelimit exceeded errors being thrown due to the GitHub API being called by the app.

Fixes #918