### PR TITLE
Python 3.11

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Python Dependencies
         uses: HassanAbouelela/actions/setup-python@setup-python_v1.4.0
         with:
-          python_version: '3.10'
+          python_version: '3.11'
 
       # Start the database early to give it a chance to get ready before
       # we start running tests.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/chrislovering/python-poetry-base:3.10-slim
+FROM ghcr.io/chrislovering/python-poetry-base:3.11-slim
 
 # Allow service to handle stops gracefully
 STOPSIGNAL SIGQUIT

--- a/poetry.lock
+++ b/poetry.lock
@@ -641,14 +641,14 @@ files = [
 
 [[package]]
 name = "nodeenv"
-version = "1.7.0"
+version = "1.8.0"
 description = "Node.js virtual environment builder"
 category = "dev"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
 files = [
-    {file = "nodeenv-1.7.0-py2.py3-none-any.whl", hash = "sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e"},
-    {file = "nodeenv-1.7.0.tar.gz", hash = "sha256:e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b"},
+    {file = "nodeenv-1.8.0-py2.py3-none-any.whl", hash = "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"},
+    {file = "nodeenv-1.8.0.tar.gz", hash = "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2"},
 ]
 
 [package.dependencies]
@@ -656,18 +656,18 @@ setuptools = "*"
 
 [[package]]
 name = "platformdirs"
-version = "3.5.0"
+version = "3.5.1"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.5.0-py3-none-any.whl", hash = "sha256:47692bc24c1958e8b0f13dd727307cff1db103fca36399f457da8e05f222fdc4"},
-    {file = "platformdirs-3.5.0.tar.gz", hash = "sha256:7954a68d0ba23558d753f73437c55f89027cf8f5108c19844d4b82e5af396335"},
+    {file = "platformdirs-3.5.1-py3-none-any.whl", hash = "sha256:e2378146f1964972c03c085bb5662ae80b2b8c06226c54b2ff4aa9483e8a13a5"},
+    {file = "platformdirs-3.5.1.tar.gz", hash = "sha256:412dae91f52a6f84830f39a8078cecd0e866cb72294a5c66808e74d5e88d251f"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
+docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.2.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
@@ -1211,5 +1211,5 @@ brotli = ["Brotli"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "3.10.*"
-content-hash = "dad8222b03904d3d26ff78b060b25974b0cd70a9a4d75171094e8c6b2d523e7e"
+python-versions = "3.11.*"
+content-hash = "7a36b961e667588a7295f4e1a16c47c736937b2e60aa71b4bb1315e6f5a8ef56"

--- a/poetry.lock
+++ b/poetry.lock
@@ -989,29 +989,29 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "ruff"
-version = "0.0.265"
+version = "0.0.267"
 description = "An extremely fast Python linter, written in Rust."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.0.265-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:30ddfe22de6ce4eb1260408f4480bbbce998f954dbf470228a21a9b2c45955e4"},
-    {file = "ruff-0.0.265-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:a11bd0889e88d3342e7bc514554bb4461bf6cc30ec115821c2425cfaac0b1b6a"},
-    {file = "ruff-0.0.265-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2a9b38bdb40a998cbc677db55b6225a6c4fadcf8819eb30695e1b8470942426b"},
-    {file = "ruff-0.0.265-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a8b44a245b60512403a6a03a5b5212da274d33862225c5eed3bcf12037eb19bb"},
-    {file = "ruff-0.0.265-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b279fa55ea175ef953208a6d8bfbcdcffac1c39b38cdb8c2bfafe9222add70bb"},
-    {file = "ruff-0.0.265-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:5028950f7af9b119d43d91b215d5044976e43b96a0d1458d193ef0dd3c587bf8"},
-    {file = "ruff-0.0.265-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4057eb539a1d88eb84e9f6a36e0a999e0f261ed850ae5d5817e68968e7b89ed9"},
-    {file = "ruff-0.0.265-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d586e69ab5cbf521a1910b733412a5735936f6a610d805b89d35b6647e2a66aa"},
-    {file = "ruff-0.0.265-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa17b13cd3f29fc57d06bf34c31f21d043735cc9a681203d634549b0e41047d1"},
-    {file = "ruff-0.0.265-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9ac13b11d9ad3001de9d637974ec5402a67cefdf9fffc3929ab44c2fcbb850a1"},
-    {file = "ruff-0.0.265-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:62a9578b48cfd292c64ea3d28681dc16b1aa7445b7a7709a2884510fc0822118"},
-    {file = "ruff-0.0.265-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d0f9967f84da42d28e3d9d9354cc1575f96ed69e6e40a7d4b780a7a0418d9409"},
-    {file = "ruff-0.0.265-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1d5a8de2fbaf91ea5699451a06f4074e7a312accfa774ad9327cde3e4fda2081"},
-    {file = "ruff-0.0.265-py3-none-win32.whl", hash = "sha256:9e9db5ccb810742d621f93272e3cc23b5f277d8d00c4a79668835d26ccbe48dd"},
-    {file = "ruff-0.0.265-py3-none-win_amd64.whl", hash = "sha256:f54facf286103006171a00ce20388d88ed1d6732db3b49c11feb9bf3d46f90e9"},
-    {file = "ruff-0.0.265-py3-none-win_arm64.whl", hash = "sha256:c78470656e33d32ddc54e8482b1b0fc6de58f1195586731e5ff1405d74421499"},
-    {file = "ruff-0.0.265.tar.gz", hash = "sha256:53c17f0dab19ddc22b254b087d1381b601b155acfa8feed514f0d6a413d0ab3a"},
+    {file = "ruff-0.0.267-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:4adbbbe314d8fcc539a245065bad89446a3cef2e0c9cf70bf7bb9ed6fe31856d"},
+    {file = "ruff-0.0.267-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:67254ae34c38cba109fdc52e4a70887de1f850fb3971e5eeef343db67305d1c1"},
+    {file = "ruff-0.0.267-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbe104f21a429b77eb5ac276bd5352fd8c0e1fbb580b4c772f77ee8c76825654"},
+    {file = "ruff-0.0.267-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:db33deef2a5e1cf528ca51cc59dd764122a48a19a6c776283b223d147041153f"},
+    {file = "ruff-0.0.267-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9adf1307fa9d840d1acaa477eb04f9702032a483214c409fca9dc46f5f157fe3"},
+    {file = "ruff-0.0.267-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:0afca3633c8e2b6c0a48ad0061180b641b3b404d68d7e6736aab301c8024c424"},
+    {file = "ruff-0.0.267-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2972241065b1c911bce3db808837ed10f4f6f8a8e15520a4242d291083605ab6"},
+    {file = "ruff-0.0.267-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f731d81cb939e757b0335b0090f18ca2e9ff8bcc8e6a1cf909245958949b6e11"},
+    {file = "ruff-0.0.267-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20c594eb56c19063ef5a57f89340e64c6550e169d6a29408a45130a8c3068adc"},
+    {file = "ruff-0.0.267-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:45d61a2b01bdf61581a2ee039503a08aa603dc74a6bbe6fb5d1ce3052f5370e5"},
+    {file = "ruff-0.0.267-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2107cec3699ca4d7bd41543dc1d475c97ae3a21ea9212238b5c2088fa8ee7722"},
+    {file = "ruff-0.0.267-py3-none-musllinux_1_2_i686.whl", hash = "sha256:786de30723c71fc46b80a173c3313fc0dbe73c96bd9da8dd1212cbc2f84cdfb2"},
+    {file = "ruff-0.0.267-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5a898953949e37c109dd242cfcf9841e065319995ebb7cdfd213b446094a942f"},
+    {file = "ruff-0.0.267-py3-none-win32.whl", hash = "sha256:d12ab329474c46b96d962e2bdb92e3ad2144981fe41b89c7770f370646c0101f"},
+    {file = "ruff-0.0.267-py3-none-win_amd64.whl", hash = "sha256:d09aecc9f5845586ba90911d815f9772c5a6dcf2e34be58c6017ecb124534ac4"},
+    {file = "ruff-0.0.267-py3-none-win_arm64.whl", hash = "sha256:7df7eb5f8d791566ba97cc0b144981b9c080a5b861abaf4bb35a26c8a77b83e9"},
+    {file = "ruff-0.0.267.tar.gz", hash = "sha256:632cec7bbaf3c06fcf0a72a1dd029b7d8b7f424ba95a574aaa135f5d20a00af7"},
 ]
 
 [[package]]
@@ -1212,4 +1212,4 @@ brotli = ["Brotli"]
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.*"
-content-hash = "7a36b961e667588a7295f4e1a16c47c736937b2e60aa71b4bb1315e6f5a8ef56"
+content-hash = "0f119307b32c59e5f726317b5f1eca3eaf818120a73f237e50fed46b389a179b"

--- a/pydis_site/apps/api/github_utils.py
+++ b/pydis_site/apps/api/github_utils.py
@@ -82,7 +82,7 @@ def generate_token() -> str:
     Refer to:
     https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#authenticating-as-a-github-app
     """
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    now = datetime.datetime.now(tz=datetime.UTC)
     return jwt.encode(
         {
             "iat": math.floor((now - datetime.timedelta(seconds=60)).timestamp()),  # Issued at
@@ -148,9 +148,9 @@ def check_run_status(run: WorkflowRun) -> str:
     created_at = (
         datetime.datetime
         .strptime(run.created_at, settings.GITHUB_TIMESTAMP_FORMAT)
-        .replace(tzinfo=datetime.timezone.utc)
+        .replace(tzinfo=datetime.UTC)
     )
-    run_time = datetime.datetime.now(tz=datetime.timezone.utc) - created_at
+    run_time = datetime.datetime.now(tz=datetime.UTC) - created_at
 
     if run.status != "completed":
         if run_time <= MAX_RUN_TIME:

--- a/pydis_site/apps/api/models/bot/message.py
+++ b/pydis_site/apps/api/models/bot/message.py
@@ -68,5 +68,5 @@ class Message(ModelReprMixin, models.Model):
         """Attribute that represents the message timestamp as derived from the snowflake id."""
         return datetime.datetime.fromtimestamp(
             ((self.id >> 22) + 1420070400000) / 1000,
-            tz=datetime.timezone.utc,
+            tz=datetime.UTC,
         )

--- a/pydis_site/apps/api/models/bot/offensive_message.py
+++ b/pydis_site/apps/api/models/bot/offensive_message.py
@@ -9,7 +9,7 @@ from pydis_site.apps.api.models.mixins import ModelReprMixin
 
 def future_date_validator(date: datetime.date) -> None:
     """Raise ValidationError if the date isn't a future date."""
-    if date < datetime.datetime.now(datetime.timezone.utc):
+    if date < datetime.datetime.now(datetime.UTC):
         raise ValidationError("Date must be a future date")
 
 

--- a/pydis_site/apps/api/tests/test_deleted_messages.py
+++ b/pydis_site/apps/api/tests/test_deleted_messages.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from django.urls import reverse
 
@@ -17,7 +17,7 @@ class DeletedMessagesWithoutActorTests(AuthenticatedAPITestCase):
 
         cls.data = {
             'actor': None,
-            'creation': datetime.now(tz=timezone.utc).isoformat(),
+            'creation': datetime.now(tz=UTC).isoformat(),
             'deletedmessage_set': [
                 {
                     'author': cls.author.id,
@@ -57,7 +57,7 @@ class DeletedMessagesWithActorTests(AuthenticatedAPITestCase):
 
         cls.data = {
             'actor': cls.actor.id,
-            'creation': datetime.now(tz=timezone.utc).isoformat(),
+            'creation': datetime.now(tz=UTC).isoformat(),
             'deletedmessage_set': [
                 {
                     'author': cls.author.id,
@@ -89,7 +89,7 @@ class DeletedMessagesLogURLTests(AuthenticatedAPITestCase):
 
         cls.deletion_context = MessageDeletionContext.objects.create(
             actor=cls.actor,
-            creation=datetime.now(tz=timezone.utc),
+            creation=datetime.now(tz=UTC),
         )
 
     def test_valid_log_url(self):

--- a/pydis_site/apps/api/tests/test_github_utils.py
+++ b/pydis_site/apps/api/tests/test_github_utils.py
@@ -39,7 +39,7 @@ class GeneralUtilityTests(unittest.TestCase):
 
         delta = datetime.timedelta(minutes=10)
         self.assertAlmostEqual(decoded["exp"] - decoded["iat"], delta.total_seconds())
-        then = datetime.datetime.now(tz=datetime.timezone.utc) + delta
+        then = datetime.datetime.now(tz=datetime.UTC) + delta
         self.assertLess(decoded["exp"], then.timestamp())
 
 
@@ -51,7 +51,7 @@ class CheckRunTests(unittest.TestCase):
         "head_sha": "sha",
         "status": "completed",
         "conclusion": "success",
-        "created_at": datetime.datetime.now(tz=datetime.timezone.utc).strftime(settings.GITHUB_TIMESTAMP_FORMAT),
+        "created_at": datetime.datetime.now(tz=datetime.UTC).strftime(settings.GITHUB_TIMESTAMP_FORMAT),
         "artifacts_url": "url",
     }
 
@@ -75,7 +75,7 @@ class CheckRunTests(unittest.TestCase):
         # Set the creation time to well before the MAX_RUN_TIME
         # to guarantee the right conclusion
         kwargs["created_at"] = (
-            datetime.datetime.now(tz=datetime.timezone.utc)
+            datetime.datetime.now(tz=datetime.UTC)
             - github_utils.MAX_RUN_TIME - datetime.timedelta(minutes=10)
         ).strftime(settings.GITHUB_TIMESTAMP_FORMAT)
 
@@ -180,7 +180,7 @@ class ArtifactFetcherTests(unittest.TestCase):
                     head_sha="action_sha",
                     created_at=(
                         datetime.datetime
-                        .now(tz=datetime.timezone.utc)
+                        .now(tz=datetime.UTC)
                         .strftime(settings.GITHUB_TIMESTAMP_FORMAT)
                     ),
                     status="completed",

--- a/pydis_site/apps/api/tests/test_infractions.py
+++ b/pydis_site/apps/api/tests/test_infractions.py
@@ -1,5 +1,5 @@
 import datetime
-from datetime import datetime as dt, timedelta, timezone
+from datetime import UTC, datetime as dt, timedelta
 from unittest.mock import patch
 from urllib.parse import quote
 
@@ -56,8 +56,8 @@ class InfractionTests(AuthenticatedAPITestCase):
             type='ban',
             reason='He terk my jerb!',
             hidden=True,
-            inserted_at=dt(2020, 10, 10, 0, 0, 0, tzinfo=timezone.utc),
-            expires_at=dt(5018, 11, 20, 15, 52, tzinfo=timezone.utc),
+            inserted_at=dt(2020, 10, 10, 0, 0, 0, tzinfo=UTC),
+            expires_at=dt(5018, 11, 20, 15, 52, tzinfo=UTC),
             active=True,
         )
         cls.ban_inactive = Infraction.objects.create(
@@ -66,7 +66,7 @@ class InfractionTests(AuthenticatedAPITestCase):
             type='ban',
             reason='James is an ass, and we won\'t be working with him again.',
             active=False,
-            inserted_at=dt(2020, 10, 10, 0, 1, 0, tzinfo=timezone.utc),
+            inserted_at=dt(2020, 10, 10, 0, 1, 0, tzinfo=UTC),
         )
         cls.timeout_permanent = Infraction.objects.create(
             user_id=cls.user.id,
@@ -74,7 +74,7 @@ class InfractionTests(AuthenticatedAPITestCase):
             type='timeout',
             reason='He has a filthy mouth and I am his soap.',
             active=True,
-            inserted_at=dt(2020, 10, 10, 0, 2, 0, tzinfo=timezone.utc),
+            inserted_at=dt(2020, 10, 10, 0, 2, 0, tzinfo=UTC),
             expires_at=None,
         )
         cls.superstar_expires_soon = Infraction.objects.create(
@@ -83,8 +83,8 @@ class InfractionTests(AuthenticatedAPITestCase):
             type='superstar',
             reason='This one doesn\'t matter anymore.',
             active=True,
-            inserted_at=dt(2020, 10, 10, 0, 3, 0, tzinfo=timezone.utc),
-            expires_at=dt.now(timezone.utc) + datetime.timedelta(hours=5),
+            inserted_at=dt(2020, 10, 10, 0, 3, 0, tzinfo=UTC),
+            expires_at=dt.now(UTC) + datetime.timedelta(hours=5),
         )
         cls.voiceban_expires_later = Infraction.objects.create(
             user_id=cls.user.id,
@@ -92,8 +92,8 @@ class InfractionTests(AuthenticatedAPITestCase):
             type='voice_ban',
             reason='Jet engine mic',
             active=True,
-            inserted_at=dt(2020, 10, 10, 0, 4, 0, tzinfo=timezone.utc),
-            expires_at=dt.now(timezone.utc) + datetime.timedelta(days=5),
+            inserted_at=dt(2020, 10, 10, 0, 4, 0, tzinfo=UTC),
+            expires_at=dt.now(UTC) + datetime.timedelta(days=5),
         )
 
     def test_list_all(self):
@@ -152,7 +152,7 @@ class InfractionTests(AuthenticatedAPITestCase):
 
     def test_filter_after(self):
         url = reverse('api:bot:infraction-list')
-        target_time = datetime.datetime.now(tz=timezone.utc) + datetime.timedelta(hours=5)
+        target_time = datetime.datetime.now(tz=UTC) + datetime.timedelta(hours=5)
         response = self.client.get(url, {'type': 'superstar', 'expires_after': target_time.isoformat()})
 
         self.assertEqual(response.status_code, 200)
@@ -161,7 +161,7 @@ class InfractionTests(AuthenticatedAPITestCase):
 
     def test_filter_before(self):
         url = reverse('api:bot:infraction-list')
-        target_time = datetime.datetime.now(tz=timezone.utc) + datetime.timedelta(hours=5)
+        target_time = datetime.datetime.now(tz=UTC) + datetime.timedelta(hours=5)
         response = self.client.get(url, {'type': 'superstar', 'expires_before': target_time.isoformat()})
 
         self.assertEqual(response.status_code, 200)
@@ -185,8 +185,8 @@ class InfractionTests(AuthenticatedAPITestCase):
 
     def test_after_before_before(self):
         url = reverse('api:bot:infraction-list')
-        target_time = datetime.datetime.now(tz=timezone.utc) + datetime.timedelta(hours=4)
-        target_time_late = datetime.datetime.now(tz=timezone.utc) + datetime.timedelta(hours=6)
+        target_time = datetime.datetime.now(tz=UTC) + datetime.timedelta(hours=4)
+        target_time_late = datetime.datetime.now(tz=UTC) + datetime.timedelta(hours=6)
         response = self.client.get(
             url,
             {'expires_before': target_time_late.isoformat(),
@@ -199,8 +199,8 @@ class InfractionTests(AuthenticatedAPITestCase):
 
     def test_after_after_before_invalid(self):
         url = reverse('api:bot:infraction-list')
-        target_time = datetime.datetime.now(tz=timezone.utc) + datetime.timedelta(hours=5)
-        target_time_late = datetime.datetime.now(tz=timezone.utc) + datetime.timedelta(hours=9)
+        target_time = datetime.datetime.now(tz=UTC) + datetime.timedelta(hours=5)
+        target_time_late = datetime.datetime.now(tz=UTC) + datetime.timedelta(hours=9)
         response = self.client.get(
             url,
             {'expires_before': target_time.isoformat(),
@@ -214,7 +214,7 @@ class InfractionTests(AuthenticatedAPITestCase):
 
     def test_permanent_after_invalid(self):
         url = reverse('api:bot:infraction-list')
-        target_time = datetime.datetime.now(tz=timezone.utc) + datetime.timedelta(hours=5)
+        target_time = datetime.datetime.now(tz=UTC) + datetime.timedelta(hours=5)
         response = self.client.get(
             url,
             {'permanent': 'true', 'expires_after': target_time.isoformat()},
@@ -226,7 +226,7 @@ class InfractionTests(AuthenticatedAPITestCase):
 
     def test_permanent_before_invalid(self):
         url = reverse('api:bot:infraction-list')
-        target_time = datetime.datetime.now(tz=timezone.utc) + datetime.timedelta(hours=5)
+        target_time = datetime.datetime.now(tz=UTC) + datetime.timedelta(hours=5)
         response = self.client.get(
             url,
             {'permanent': 'true', 'expires_before': target_time.isoformat()},
@@ -238,7 +238,7 @@ class InfractionTests(AuthenticatedAPITestCase):
 
     def test_nonpermanent_before(self):
         url = reverse('api:bot:infraction-list')
-        target_time = datetime.datetime.now(tz=timezone.utc) + datetime.timedelta(hours=6)
+        target_time = datetime.datetime.now(tz=UTC) + datetime.timedelta(hours=6)
         response = self.client.get(
             url,
             {'permanent': 'false', 'expires_before': target_time.isoformat()},
@@ -370,7 +370,7 @@ class CreationTests(AuthenticatedAPITestCase):
         infraction = Infraction.objects.get(id=response.json()['id'])
         self.assertAlmostEqual(
             infraction.inserted_at,
-            dt.now(timezone.utc),
+            dt.now(UTC),
             delta=timedelta(seconds=2)
         )
         self.assertEqual(infraction.expires_at.isoformat(), data['expires_at'])
@@ -814,7 +814,7 @@ class SerializerTests(AuthenticatedAPITestCase):
             actor_id=self.user.id,
             type=_type,
             reason='A reason.',
-            expires_at=dt(5018, 11, 20, 15, 52, tzinfo=timezone.utc),
+            expires_at=dt(5018, 11, 20, 15, 52, tzinfo=UTC),
             active=active
         )
 

--- a/pydis_site/apps/api/tests/test_models.py
+++ b/pydis_site/apps/api/tests/test_models.py
@@ -1,4 +1,4 @@
-from datetime import datetime as dt, timezone
+from datetime import UTC, datetime as dt
 
 from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase, TestCase
@@ -41,7 +41,7 @@ class NitroMessageLengthTest(TestCase):
         self.context = MessageDeletionContext.objects.create(
             id=50,
             actor=self.user,
-            creation=dt.now(timezone.utc)
+            creation=dt.now(UTC)
         )
 
     def test_create(self):
@@ -99,7 +99,7 @@ class StringDunderMethodTests(SimpleTestCase):
                         name='shawn',
                         discriminator=555,
                     ),
-                    creation=dt.now(timezone.utc)
+                    creation=dt.now(UTC)
                 ),
                 embeds=[]
             ),
@@ -118,7 +118,7 @@ class StringDunderMethodTests(SimpleTestCase):
             OffensiveMessage(
                 id=602951077675139072,
                 channel_id=291284109232308226,
-                delete_date=dt(3000, 1, 1, tzinfo=timezone.utc)
+                delete_date=dt(3000, 1, 1, tzinfo=UTC)
             ),
             OffTopicChannelName(name='bob-the-builders-playground'),
             Role(
@@ -132,7 +132,7 @@ class StringDunderMethodTests(SimpleTestCase):
                     name='shawn',
                     discriminator=555,
                 ),
-                creation=dt.now(tz=timezone.utc)
+                creation=dt.now(tz=UTC)
             ),
             User(
                 id=5,
@@ -151,7 +151,7 @@ class StringDunderMethodTests(SimpleTestCase):
                 hidden=True,
                 type='kick',
                 reason='He terk my jerb!',
-                expires_at=dt(5018, 11, 20, 15, 52, tzinfo=timezone.utc)
+                expires_at=dt(5018, 11, 20, 15, 52, tzinfo=UTC)
             ),
             Reminder(
                 author=User(
@@ -165,7 +165,7 @@ class StringDunderMethodTests(SimpleTestCase):
                     '267624335836053506/291284109232308226/463087129459949587'
                 ),
                 content="oh no",
-                expiration=dt(5018, 11, 20, 15, 52, tzinfo=timezone.utc)
+                expiration=dt(5018, 11, 20, 15, 52, tzinfo=UTC)
             ),
             NominationEntry(
                 nomination_id=self.nomination.id,

--- a/pydis_site/apps/api/tests/test_nominations.py
+++ b/pydis_site/apps/api/tests/test_nominations.py
@@ -1,4 +1,4 @@
-from datetime import datetime as dt, timedelta, timezone
+from datetime import UTC, datetime as dt, timedelta
 
 from django.urls import reverse
 
@@ -38,7 +38,7 @@ class CreationTests(AuthenticatedAPITestCase):
         )
         self.assertAlmostEqual(
             nomination.inserted_at,
-            dt.now(timezone.utc),
+            dt.now(UTC),
             delta=timedelta(seconds=2)
         )
         self.assertEqual(nomination.user.id, data['user'])
@@ -319,7 +319,7 @@ class NominationTests(AuthenticatedAPITestCase):
 
         self.assertAlmostEqual(
             nomination.ended_at,
-            dt.now(timezone.utc),
+            dt.now(UTC),
             delta=timedelta(seconds=2)
         )
         self.assertFalse(nomination.active)

--- a/pydis_site/apps/api/tests/test_offensive_message.py
+++ b/pydis_site/apps/api/tests/test_offensive_message.py
@@ -16,7 +16,7 @@ class CreationTests(AuthenticatedAPITestCase):
             'delete_date': delete_at.isoformat()[:-1]
         }
 
-        aware_delete_at = delete_at.replace(tzinfo=datetime.timezone.utc)
+        aware_delete_at = delete_at.replace(tzinfo=datetime.UTC)
 
         response = self.client.post(url, data=data)
         self.assertEqual(response.status_code, 201)
@@ -73,7 +73,7 @@ class ListTests(AuthenticatedAPITestCase):
     @classmethod
     def setUpTestData(cls):
         delete_at = datetime.datetime.now() + datetime.timedelta(days=1)  # noqa: DTZ005
-        aware_delete_at = delete_at.replace(tzinfo=datetime.timezone.utc)
+        aware_delete_at = delete_at.replace(tzinfo=datetime.UTC)
 
         cls.messages = [
             {
@@ -111,7 +111,7 @@ class ListTests(AuthenticatedAPITestCase):
 class DeletionTests(AuthenticatedAPITestCase):
     @classmethod
     def setUpTestData(cls):
-        delete_at = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(days=1)
+        delete_at = datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=1)
 
         cls.valid_offensive_message = OffensiveMessage.objects.create(
             id=602951077675139072,
@@ -135,7 +135,7 @@ class DeletionTests(AuthenticatedAPITestCase):
 class NotAllowedMethodsTests(AuthenticatedAPITestCase):
     @classmethod
     def setUpTestData(cls):
-        delete_at = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(days=1)
+        delete_at = datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=1)
 
         cls.valid_offensive_message = OffensiveMessage.objects.create(
             id=602951077675139072,

--- a/pydis_site/apps/api/tests/test_reminders.py
+++ b/pydis_site/apps/api/tests/test_reminders.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from django.forms.models import model_to_dict
 from django.urls import reverse
@@ -59,7 +59,7 @@ class ReminderCreationTests(AuthenticatedAPITestCase):
         data = {
             'author': self.author.id,
             'content': 'Remember to...wait what was it again?',
-            'expiration': datetime.now(tz=timezone.utc).isoformat(),
+            'expiration': datetime.now(tz=UTC).isoformat(),
             'jump_url': "https://www.google.com",
             'channel_id': 123,
             'mentions': [8888, 9999],
@@ -91,7 +91,7 @@ class ReminderDeletionTests(AuthenticatedAPITestCase):
         cls.reminder = Reminder.objects.create(
             author=cls.author,
             content="Don't forget to set yourself a reminder",
-            expiration=datetime.now(timezone.utc),
+            expiration=datetime.now(UTC),
             jump_url="https://www.decliningmentalfaculties.com",
             channel_id=123
         )
@@ -122,7 +122,7 @@ class ReminderListTests(AuthenticatedAPITestCase):
         cls.reminder_one = Reminder.objects.create(
             author=cls.author,
             content="We should take Bikini Bottom, and push it somewhere else!",
-            expiration=datetime.now(timezone.utc),
+            expiration=datetime.now(UTC),
             jump_url="https://www.icantseemyforehead.com",
             channel_id=123
         )
@@ -130,7 +130,7 @@ class ReminderListTests(AuthenticatedAPITestCase):
         cls.reminder_two = Reminder.objects.create(
             author=cls.author,
             content="Gahhh-I love being purple!",
-            expiration=datetime.now(timezone.utc),
+            expiration=datetime.now(UTC),
             jump_url="https://www.goofygoobersicecreampartyboat.com",
             channel_id=123,
             active=False
@@ -176,7 +176,7 @@ class ReminderRetrieveTests(AuthenticatedAPITestCase):
         cls.reminder = Reminder.objects.create(
             author=cls.author,
             content="Reminder content",
-            expiration=datetime.now(timezone.utc),
+            expiration=datetime.now(UTC),
             jump_url="http://example.com/",
             channel_id=123
         )
@@ -204,7 +204,7 @@ class ReminderUpdateTests(AuthenticatedAPITestCase):
         cls.reminder = Reminder.objects.create(
             author=cls.author,
             content="Squash those do-gooders",
-            expiration=datetime.now(timezone.utc),
+            expiration=datetime.now(UTC),
             jump_url="https://www.decliningmentalfaculties.com",
             channel_id=123
         )

--- a/pydis_site/apps/api/tests/test_rules.py
+++ b/pydis_site/apps/api/tests/test_rules.py
@@ -56,7 +56,7 @@ class RuleCorrectnessTests(AuthenticatedAPITestCase):
         )
 
         markdown_rules = []
-        for line in markdown_rules_path.read_text().splitlines():
+        for line in markdown_rules_path.read_text(encoding="utf8").splitlines():
             matches = self.markdown_rule_re.match(line)
             if matches is not None:
                 markdown_rules.append(matches.group(1))

--- a/pydis_site/apps/api/tests/test_validators.py
+++ b/pydis_site/apps/api/tests/test_validators.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from django.core.exceptions import ValidationError
 from django.test import TestCase
@@ -23,8 +23,8 @@ class BotSettingValidatorTests(TestCase):
 
 class OffensiveMessageValidatorsTests(TestCase):
     def test_accepts_future_date(self):
-        future_date_validator(datetime(3000, 1, 1, tzinfo=timezone.utc))
+        future_date_validator(datetime(3000, 1, 1, tzinfo=UTC))
 
     def test_rejects_non_future_date(self):
         with self.assertRaises(ValidationError):
-            future_date_validator(datetime(1000, 1, 1, tzinfo=timezone.utc))
+            future_date_validator(datetime(1000, 1, 1, tzinfo=UTC))

--- a/pydis_site/apps/api/viewsets/bot/infraction.py
+++ b/pydis_site/apps/api/viewsets/bot/infraction.py
@@ -190,7 +190,7 @@ class InfractionViewSet(
             except ValueError:
                 raise ValidationError({'expires_after': ['failed to convert to datetime']})
             additional_filters['expires_at__gte'] = expires_after_parsed.replace(
-                tzinfo=datetime.timezone.utc
+                tzinfo=datetime.UTC
             )
 
         filter_expires_before = self.request.query_params.get('expires_before')
@@ -200,7 +200,7 @@ class InfractionViewSet(
             except ValueError:
                 raise ValidationError({'expires_before': ['failed to convert to datetime']})
             additional_filters['expires_at__lte'] = expires_before_parsed.replace(
-                tzinfo=datetime.timezone.utc
+                tzinfo=datetime.UTC
             )
 
         if 'expires_at__lte' in additional_filters and 'expires_at__gte' in additional_filters:

--- a/pydis_site/apps/content/tests/test_utils.py
+++ b/pydis_site/apps/content/tests/test_utils.py
@@ -17,7 +17,7 @@ from pydis_site.apps.content.tests.helpers import (
     BASE_PATH, MockPagesTestCase, PARSED_CATEGORY_INFO, PARSED_HTML, PARSED_METADATA
 )
 
-_time = datetime.datetime(2022, 10, 10, 10, 10, 10, tzinfo=datetime.timezone.utc)
+_time = datetime.datetime(2022, 10, 10, 10, 10, 10, tzinfo=datetime.UTC)
 _time_str = _time.strftime(settings.GITHUB_TIMESTAMP_FORMAT)
 TEST_COMMIT_KWARGS = {
     "sha": "123",

--- a/pydis_site/apps/content/utils.py
+++ b/pydis_site/apps/content/utils.py
@@ -132,7 +132,7 @@ def set_tag_commit(tag: Tag) -> None:
         tag.last_commit = Commit(
             sha="68da80efc00d9932a209d5cccd8d344cec0f09ea",
             message="Initial Commit\n\nTHIS IS FAKE DEMO DATA",
-            date=datetime.datetime(2018, 2, 3, 12, 20, 26, tzinfo=datetime.timezone.utc),
+            date=datetime.datetime(2018, 2, 3, 12, 20, 26, tzinfo=datetime.UTC),
             authors=json.dumps([{"name": "Joseph", "email": "joseph@josephbanks.me"}]),
         )
         return
@@ -154,7 +154,7 @@ def set_tag_commit(tag: Tag) -> None:
     date = (
         datetime.datetime
         .strptime(committer["date"], settings.GITHUB_TIMESTAMP_FORMAT)
-        .replace(tzinfo=datetime.timezone.utc)
+        .replace(tzinfo=datetime.UTC)
     )
 
     if author["email"] == committer["email"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ psycopg = {extras = ["binary"], version = "3.1.9"}
 [tool.poetry.group.dev.dependencies]
 python-dotenv = "1.0.0"
 taskipy = "1.10.4"
-ruff = "0.0.265"
+ruff = "0.0.267"
 
 [tool.poetry.group.lint.dependencies]
 pre-commit = "3.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Python Discord <info@pythondiscord.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "3.10.*"
+python = "3.11.*"
 
 django = "4.2.1"
 django-distill = "3.1.3"
@@ -24,12 +24,12 @@ python-frontmatter = "1.0.0"
 pyyaml = "6.0"
 sentry-sdk = "1.22.2"
 whitenoise = "6.4.0"
-psycopg = {extras = ["binary"], version = "^3.1.9"}
+psycopg = {extras = ["binary"], version = "3.1.9"}
 
 [tool.poetry.group.dev.dependencies]
 python-dotenv = "1.0.0"
 taskipy = "1.10.4"
-ruff = "^0.0.265"
+ruff = "0.0.265"
 
 [tool.poetry.group.lint.dependencies]
 pre-commit = "3.3.1"
@@ -42,7 +42,7 @@ requires = ["poetry-core>=1.2.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 extend-exclude = [".cache"]
 ignore = [
     "ANN002", "ANN003", "ANN101", "ANN102", "ANN204", "ANN206", "ANN401",


### PR DESCRIPTION
This bumps the site up to using Python 3.11. This includes the poetry project file, within the Docker image, in CI, and the target version for ruff.

This also fixes ruff linting errors by using the new datetime.UTC alias present in 3.11.

While running the test suite locally I noticed a test that failed on a Windows host, so updated that too.