### PR TITLE
Drop redirect usage from URL references

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you're looking to contribute or play around with the code, take a look at [th
 [7]: https://coveralls.io/repos/github/python-discord/site/badge.svg?branch=main
 [8]: https://coveralls.io/github/python-discord/site?branch=main
 [9]: https://pythondiscord.com
-[10]: https://pythondiscord.com/pages/contributing/site/
+[10]: https://pythondiscord.com/pages/guides/pydis-guides/contributing/site/
 [11]: https://github.com/python-discord/site/issues
 [12]: https://raw.githubusercontent.com/python-discord/branding/main/logos/badge/badge_github.svg
 [13]: https://discord.gg/python

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/hosts-file.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/hosts-file.md
@@ -8,7 +8,7 @@ toc: 3
 # What's a hosts file?
 The hosts file maps a hostname/domain to an IP address, allowing you to visit a given domain on your browser and have it resolve by your system to the given IP address, even if it's pointed back to your own system or network.
 
-When staging a local [Site](https://pythondiscord.com/pages/contributing/site/) project, you may want to add an entries to your hosts file so you can visit the site with the domain `http://pythondiscord.local`. This is purely for convenience, and you can use `localhost` or `127.0.0.1` instead if you prefer.
+When staging a local [Site](https://pythondiscord.com/pages/guides/pydis-guides/contributing/site/) project, you may want to add an entries to your hosts file so you can visit the site with the domain `http://pythondiscord.local`. This is purely for convenience, and you can use `localhost` or `127.0.0.1` instead if you prefer.
 
 # What to add
 You would add the following entry to your hosts file.

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/site.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/site.md
@@ -92,7 +92,7 @@ docker-compose up
 
 The `-d` option can be appended to the command to run in detached mode. This runs the containers in the background so the current terminal session is available for use with other things.
 
-If you get any Docker related errors, reference the [Possible Issues](https://pythondiscord.com/pages/contributing/docker/#possible-issues") section of the Docker page.
+If you get any Docker related errors, reference the [Possible Issues](https://pythondiscord.com/pages/guides/pydis-guides/contributing/docker/#possible-issues") section of the Docker page.
 {: .notification .is-warning }
 
 ## Run on the host

--- a/pydis_site/apps/content/resources/guides/pydis-guides/how-to-contribute-a-page.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/how-to-contribute-a-page.md
@@ -3,8 +3,8 @@ title: How to Contribute a Page
 description: Learn how to write and publish a page to this website.
 icon: fas fa-info
 relevant_links:
-    Contributing to Site: https://pythondiscord.com/pages/contributing/site/
-    Using Git: https://pythondiscord.com/pages/contributing/working-with-git/
+    Contributing to Site: https://pythondiscord.com/pages/guides/pydis-guides/contributing/site/
+    Using Git: https://pythondiscord.com/pages/guides/pydis-guides/contributing/working-with-git/
 toc: 4
 ---
 
@@ -14,8 +14,8 @@ If you are interested in writing or modifying pages seen here on the site, follo
 For further assistance and help with contributing pages, send a message to the `#dev-contrib` channel in the Discord server!
 
 ## Prerequisites
-Before working on a new page, you have to [setup the site project locally](https://pythondiscord.com/pages/contributing/site/).
-It is also a good idea to familiarize yourself with the [git workflow](https://pythondiscord.com/pages/contributing/working-with-git/), as it is part of the contribution workflow.
+Before working on a new page, you have to [setup the site project locally](https://pythondiscord.com/pages/guides/pydis-guides/contributing/site/).
+It is also a good idea to familiarize yourself with the [git workflow](https://pythondiscord.com/pages/guides/pydis-guides/contributing/working-with-git/), as it is part of the contribution workflow.
 
 Additionally, please submit your proposed page or modification to a page as an [issue in the site repository](https://github.com/python-discord/site/issues), or discuss it in the `#dev-contrib` channel in the server.
 As website changes require staff approval, discussing the page content beforehand helps with accelerating the contribution process, and avoids wasted work in the event the proposed page is not accepted.
@@ -68,8 +68,8 @@ title: How to Contribute a Page
 description: Learn how to write and publish a page to this website.
 icon: fas fa-info
 relevant_links:
-    Contributing to Site: https://pythondiscord.com/pages/contributing/site/
-    Using Git: https://pythondiscord.com/pages/contributing/working-with-git/
+    Contributing to Site: https://pythondiscord.com/pages/guides/pydis-guides/contributing/site/
+    Using Git: https://pythondiscord.com/pages/guides/pydis-guides/contributing/working-with-git/
 ---
 
 Pages, which include guides, articles, and other static content,...

--- a/pydis_site/apps/content/resources/server-info/roles.md
+++ b/pydis_site/apps/content/resources/server-info/roles.md
@@ -33,7 +33,7 @@ It’s difficult to precisely quantify contributions, but we’ve come up with t
 - The member has made several significant contributions to our projects.
 - The member has a positive influence in our contributors subcommunity.
 
-The role will be assigned at the discretion of the Admin Team in consultation with the Core Developers Team. Check out our [walkthrough](/pages/contributing/) to get started contributing.
+The role will be assigned at the discretion of the Admin Team in consultation with the Core Developers Team. Check out our [walkthrough](/pages/guides/pydis-guides/contributing/) to get started contributing.
 
 ---
 


### PR DESCRIPTION
Just one separate, and present beforehand, broken link remains:

    $ httrack -E --robots=0  --spider http://127.0.0.1:8000 -v | grep 404
    20:18:51	Error: 	"Not Found" (404) at link 127.0.0.1:8000/events/game-jam-2020/technical-requirements/ (from 127.0.0.1:8000/events/game-jams/2020/judging/)

Closes #681.