### PR TITLE
Fix link to teachingpython episode

### DIFF
--- a/pydis_site/templates/home/timeline.html
+++ b/pydis_site/templates/home/timeline.html
@@ -69,7 +69,7 @@
           <h2>We're on the Teaching Python podcast!</h2>
           <p class="color-contrast-medium">Leon joins Sean and Kelly on the Teaching Python podcast to discuss how the pandemic has
             changed the way we learn, and what role communities like Python Discord can play in this new world.
-            You can find the episode <a href="https://teachingpython.fm/63"> at teachingpython.fm</a>.
+            You can find the episode <a href="https://www.teachingpython.fm/63">at teachingpython.fm</a>.
           </p>
 
           <iframe width="100%" height="166" frameborder="0" scrolling="no"


### PR DESCRIPTION
Also removes a superfluous space. Closes #1043.