### PR TITLE
Fix a typo in bot.md

### DIFF
--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot.md
@@ -132,7 +132,7 @@ With all of the above setup, you can run The projec with `docker compose up`. Th
 
 Some other useful docker commands are as follows:
 
-1. `docker compose pull` this pulls updates for all non-bot services, such as psotgres, redis and our [site](../site) project!
+1. `docker compose pull` this pulls updates for all non-bot services, such as postgres, redis and our [site](../site) project!
 1. `docker compose build` this rebuilds the bot's docker image, this is only needed if you need to make changes to the bot's dependencies, or the Dockerfile itself.
 
 Your bot is now running, all inside Docker.


### PR DESCRIPTION
This PR is to fix a typo found in bot.md file. Corrects the typo "psotgres" to "postgres". 