### PR TITLE
Remove the redirect FilterList on migration

### DIFF
--- a/pydis_site/apps/api/migrations/0092_remove_redirect_filter_list.py
+++ b/pydis_site/apps/api/migrations/0092_remove_redirect_filter_list.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+from django.apps.registry import Apps
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+
+
+def forward(apps: Apps, _: BaseDatabaseSchemaEditor) -> None:
+    apps.get_model("api", "FilterList").objects.filter(name="redirect").delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0091_antispam_filter_list"),
+    ]
+
+    operations = [migrations.RunPython(forward)]


### PR DESCRIPTION
Closes #1110 Closes BOT-3FA

This redirect filter list does not have any filters, nor does it have a bot implementation.
It is something that we were working on, but has been stalled for a while.

The presence of this filter list also causes the bot to warn on startup due to it finding a filter list with no implementation.
This commit removes the FilterList, which can be added back if/when we support this filter type in bot.

An export of this filter list prior to deletion can be found on [this notion page](https://www.notion.so/pythondiscord/Redirect-filter-list-export-8299555f454c4a9d8f37d770021e9773) (for those with access).