### PR TITLE
removing margin-left property from base.css to fix the overflow 

### DIFF
--- a/pydis_site/static/css/base/base.css
+++ b/pydis_site/static/css/base/base.css
@@ -54,7 +54,6 @@ main.site-content {
     padding-left: 2.5rem;
     padding-right: 2.5rem;
     background-color: #697ec4ff;
-    margin-left: 0.5rem;
     transition: all 0.2s cubic-bezier(.25,.8,.25,1);
     overflow: hidden;
 }


### PR DESCRIPTION
## Summary
Fixes #1015 [Issue](https://github.com/python-discord/site/issues/1015)

## Description of changes
removing the margin-left property from base.css to fix the overflow caused by the discord button logo on the top right of the page when screen size is lowered.

### I confirm I have:
- [X] Joined the [Python Discord community](discord.gg/python)
- [X] Read the [Code of Conduct](https://www.pydis.com/pages/code-of-conduct) and agree to it
- [X] I have discussed implementing this feature on the relevant service (Discord, GitHub, etc.)
