### PR TITLE
Add endpoint to fetch filters in JSON format

### DIFF
--- a/pydis_site/apps/resources/tests/test_views.py
+++ b/pydis_site/apps/resources/tests/test_views.py
@@ -27,3 +27,14 @@ class TestResourcesView(TestCase):
         url = reverse("resources:index", kwargs={"resource_type": "urinal-cake"})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
+
+
+class TestResourceFilterView(TestCase):
+    def test_resource_filter_response(self):
+        """Check that the filter endpoint returns JSON-formatted filters."""
+        url = reverse('resources:filters')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        self.assertIn('difficulty', content)
+        self.assertIsInstance(content['difficulty'], list)

--- a/pydis_site/apps/resources/urls.py
+++ b/pydis_site/apps/resources/urls.py
@@ -1,11 +1,12 @@
 from django_distill import distill_path
 
-from pydis_site.apps.resources.views import ResourceView
+from pydis_site.apps.resources.views import ResourceView, ResourceFilterView
 
 app_name = "resources"
 urlpatterns = [
     # Using `distill_path` instead of `path` allows this to be available
     # in static preview builds.
     distill_path("", ResourceView.as_view(), name="index"),
+    distill_path("filters", ResourceFilterView.as_view(), name="filters"),
     distill_path("<resource_type>/", ResourceView.as_view(), name="index"),
 ]

--- a/pydis_site/apps/resources/views.py
+++ b/pydis_site/apps/resources/views.py
@@ -2,7 +2,7 @@ import json
 
 from django.apps import apps
 from django.core.handlers.wsgi import WSGIRequest
-from django.http import HttpResponse, HttpResponseNotFound
+from django.http import HttpResponse, HttpResponseNotFound, JsonResponse
 from django.shortcuts import render
 from django.views import View
 
@@ -38,3 +38,12 @@ class ResourceView(View):
                 "resource_type": resource_type,
             }
         )
+
+
+class ResourceFilterView(View):
+    """Exposes resource filters for the bot."""
+
+    def get(self, request: WSGIRequest) -> HttpResponse:
+        """Return resource filters as JSON."""
+        app = apps.get_app_config(APP_NAME)
+        return JsonResponse(app.valid_filters)


### PR DESCRIPTION
While this is an API endpoint consumed by the bot, keep it in the
`resources` app instead of the `api` app, as all the logic and data for
resources is contained within the `resources` app and we don't want to
start messing around with that.

The response format from the endpoint is as follows:

    {
        "topics": [
            "algorithms-and-data-structures",
            "data-science",
            "databases",
            "discord-bots",
            "game-development",
            "general",
            "microcontrollers",
            "security",
            "software-design",
            "testing",
            "tooling",
            "user-interface",
            "web-development",
            "other"
        ],
        "payment_tiers": [
            "free",
            "paid",
            "subscription"
        ],
        "type": [
            "book",
            "community",
            "course",
            "interactive",
            "podcast",
            "project-ideas",
            "tool",
            "tutorial",
            "video"
        ],
        "difficulty": [
            "beginner",
            "intermediate"
        ]
    }

Closes #710.

