### PR TITLE
Insert deleted messages as a Batch

### DIFF
--- a/pydis_site/apps/api/serializers.py
+++ b/pydis_site/apps/api/serializers.py
@@ -151,12 +151,9 @@ class MessageDeletionContextSerializer(ModelSerializer):
         """
         messages = validated_data.pop('deletedmessage_set')
         deletion_context = MessageDeletionContext.objects.create(**validated_data)
-        for message in messages:
-            DeletedMessage.objects.create(
-                deletion_context=deletion_context,
-                **message
-            )
-
+        DeletedMessage.objects.bulk_create(
+            DeletedMessage(deletion_context=deletion_context, **message) for message in messages
+        )
         return deletion_context
 
 


### PR DESCRIPTION
Sentry is sending an N+1 query [alert](https://python-discord.sentry.io/issues/4727001467/?referrer=slack) because of the way we were inserting messages (one by one)

