### PR TITLE
Download pull request artifact using curl

### DIFF
--- a/.github/workflows/status-embed.yaml
+++ b/.github/workflows/status-embed.yaml
@@ -39,7 +39,7 @@ jobs:
           curl -s -H "Authorization: token $GITHUB_TOKEN" ${{ github.event.workflow_run.artifacts_url }} > artifacts.json
           DOWNLOAD_URL=$(cat artifacts.json | jq -r '.artifacts[] | select(.name == "pull-request-payload") | .archive_download_url')
           [ -z "$DOWNLOAD_URL" ] && exit 1
-          wget --header="Authorization: token $GITHUB_TOKEN" -O pull_request_payload.zip $DOWNLOAD_URL || exit 2
+          curl -sSL -H "Authorization: token $GITHUB_TOKEN" -o pull_request_payload.zip $DOWNLOAD_URL || exit 2
           unzip -p pull_request_payload.zip > pull_request_payload.json
           [ -s pull_request_payload.json ] || exit 3
           echo "pr_author_login=$(jq -r '.user.login // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
We've started having issues with downloading the pull_request_info artifact using `wget`.

The issue seems to only happen when requesting the artifact that belongs to the `site` repo, as it works for the rest.

Weirdly enough, replacing `wget` with `curl` solves the issue.

A verbose output of `wget` would spit out a `403` status code, tellig us we're unauthorized for this action. See this [action run](https://github.com/python-discord/site/actions/runs/7222226626/job/19678802520) 
