### PR TITLE
Prevent loading related object when updating tags

### DIFF
--- a/pydis_site/apps/content/utils.py
+++ b/pydis_site/apps/content/utils.py
@@ -206,9 +206,9 @@ def record_tags(tags: list[Tag]) -> None:
             # pretend it's previous state is the current state
             old_tag = new_tag
 
-        if old_tag.sha == new_tag.sha and old_tag.last_commit is not None:
+        if old_tag.sha == new_tag.sha and old_tag.last_commit_id is not None:
             # We still have an up-to-date commit entry
-            new_tag.last_commit = old_tag.last_commit
+            new_tag.last_commit_id = old_tag.last_commit_id
 
         new_tag.save()
 


### PR DESCRIPTION
We can simply save by the ID here, we do not need any other data from the related object.