### PR TITLE
Add 'Software Design by Example' to resources. (fix #1193)

### DIFF
--- a/pydis_site/apps/resources/resources/software_design_by_example.yaml
+++ b/pydis_site/apps/resources/resources/software_design_by_example.yaml
@@ -1,6 +1,6 @@
 name: Software Design by Example
 description: A tool-based introduction to Software Design with Python. This book teaches
-  design by explaining examples of small versions of familiar tools to show how 
+  design by explaining examples of small versions of familiar tools to show how
   experienced software designers think. It introduces some fundamental ideas in computer
   science that many self-taught programmers haven’t encountered.
 title_image: https://third-bit.com/sdxpy/logo.svg

--- a/pydis_site/apps/resources/resources/software_design_by_example.yaml
+++ b/pydis_site/apps/resources/resources/software_design_by_example.yaml
@@ -3,7 +3,8 @@ description: A tool-based introduction to Software Design with Python. This book
   design by explaining examples of small versions of familiar tools to show how
   experienced software designers think. It introduces some fundamental ideas in computer
   science that many self-taught programmers haven’t encountered.
-title_image: https://third-bit.com/sdxpy/logo.svg
+icon_image: https://third-bit.com/sdxpy/logo.svg
+icon_size: 50
 title_url: https://third-bit.com/sdxpy/
 urls:
 - icon: branding/goodreads

--- a/pydis_site/apps/resources/resources/software_design_by_example.yaml
+++ b/pydis_site/apps/resources/resources/software_design_by_example.yaml
@@ -1,0 +1,21 @@
+name: Software Design by Example
+description: A tool-based introduction to Software Design with Python. This book teaches
+  design by explaining examples of small versions of familiar tools to show how 
+  experienced software designers think. It introduces some fundamental ideas in computer
+  science that many self-taught programmers haven’t encountered.
+title_image: https://third-bit.com/sdxpy/logo.svg
+title_url: https://third-bit.com/sdxpy/
+urls:
+- icon: branding/github
+  url: https://github.com/gvwilson/sdxpy
+  color: black
+tags:
+  topics:
+    - general
+    - software design
+  payment_tiers:
+    - free
+  difficulty:
+    - intermediate
+  type:
+    - book

--- a/pydis_site/apps/resources/resources/software_design_by_example.yaml
+++ b/pydis_site/apps/resources/resources/software_design_by_example.yaml
@@ -6,6 +6,9 @@ description: A tool-based introduction to Software Design with Python. This book
 title_image: https://third-bit.com/sdxpy/logo.svg
 title_url: https://third-bit.com/sdxpy/
 urls:
+- icon: branding/goodreads
+  url: https://www.goodreads.com/book/show/199430059-software-design-by-example
+  color: black
 - icon: branding/github
   url: https://github.com/gvwilson/sdxpy
   color: black
@@ -15,6 +18,7 @@ tags:
     - software design
   payment_tiers:
     - free
+    - paid
   difficulty:
     - intermediate
   type:


### PR DESCRIPTION
This PR adds [Software Design by Example](https://third-bit.com/sdxpy/) by @gvwilson to the resources page. Maybe the description could be improved.

Fixes #1193.