### PR TITLE
Ensure messages returned for metricity data do not match all excluded channels

### DIFF
--- a/pydis_site/apps/api/models/bot/metricity.py
+++ b/pydis_site/apps/api/models/bot/metricity.py
@@ -49,7 +49,7 @@ class Metricity:
             WHERE
                 author_id = '%s'
                 AND NOT is_deleted
-                AND channel_id != ANY(%s)
+                AND channel_id != ALL(%s)
             """,
             [user_id, EXCLUDE_CHANNELS]
         )
@@ -77,7 +77,7 @@ class Metricity:
                 WHERE
                     author_id='%s'
                     AND NOT is_deleted
-                    AND channel_id != ANY(%s)
+                    AND channel_id != ALL(%s)
                 GROUP BY interval
             ) block_query;
             """,
@@ -147,7 +147,7 @@ class Metricity:
             WHERE
                 author_id = ANY(%s)
                 AND NOT is_deleted
-                AND channel_id != ANY(%s)
+                AND channel_id != ALL(%s)
                 AND created_at > now() - interval '%s days'
             GROUP BY author_id
             """,


### PR DESCRIPTION
The logic here was wrong due to the `!=` requiring us to use negative logic. This meant that messages in excluded channels were still being used for message count.

Tests with my user:
```sql
SELECT
    COUNT(*)
FROM messages
WHERE
    author_id = '126811506632294400'
    AND NOT is_deleted
```
\>>> 111,045

```sql
SELECT
    COUNT(*)
FROM messages
WHERE
    author_id = '126811506632294400'
    AND NOT is_deleted
    AND channel_id != ANY('{267659945086812160,607247579608121354}')
```
\>>> 111,045

```sql
SELECT
    COUNT(*)
FROM messages
WHERE
    author_id = '126811506632294400'
    AND NOT is_deleted
    AND channel_id != ALL('{267659945086812160,607247579608121354}')
```
\>>> 110,402