### PR TITLE
Fix legacy Font Awesome icon classes

### DIFF
--- a/pydis_site/apps/resources/templatetags/get_category_icon.py
+++ b/pydis_site/apps/resources/templatetags/get_category_icon.py
@@ -20,7 +20,7 @@ _ICONS = {
     "Other": "fa-question-circle",
     "Paid": "fa-dollar-sign",
     "Podcast": "fa-microphone-alt",
-    "Project Ideas": "fa-lightbulb-o",
+    "Project Ideas": "fa-lightbulb",
     "Security": "fa-solid fa-lock",
     "Software Design": "fa-paint-brush",
     "Subscription": "fa-credit-card",

--- a/pydis_site/templates/events/pages/code-jams/10/_index.html
+++ b/pydis_site/templates/events/pages/code-jams/10/_index.html
@@ -29,7 +29,7 @@
             Taking captchas to the next level in an effort to foil some of the new AIs. The captchas are image based with a twist.
         </p>
         <p>
-            <a href="https://github.com/thijsfranck/the-dynamic-typists" title="The Dynamic Typists GitHub Repository" target="_blank" rel="noopener"><i class="fa fa-github"></i> GitHub Repository</a>
+            <a href="https://github.com/thijsfranck/the-dynamic-typists" title="The Dynamic Typists GitHub Repository" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub Repository</a>
             <br/>
 
         </p>
@@ -40,7 +40,7 @@
             Given a snippet of code, create an image of the code to easily share and also embed the code into the image of the code itself.
         </p>
         <p>
-            <a href="https://github.com/StoneSteel27/The-Magic-Methods" title="The Magic Methods GitHub Repository" target="_blank" rel="noopener"><i class="fa fa-github"></i> GitHub Repository</a>
+            <a href="https://github.com/StoneSteel27/The-Magic-Methods" title="The Magic Methods GitHub Repository" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub Repository</a>
             <br/>
         </p>
 
@@ -49,7 +49,7 @@
         <p class="my-1">
             Image manipulation puzzle game. Adjust image manipulation sliders to find secret codes.
         <p>
-            <a href="https://github.com/Flow-Glow/Code-Jam-2023-Async-Aggregators" title="The Async Aggregators GitHub Repository" target="_blank" rel="noopener"><i class="fa fa-github"></i> GitHub Repository</a>
+            <a href="https://github.com/Flow-Glow/Code-Jam-2023-Async-Aggregators" title="The Async Aggregators GitHub Repository" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub Repository</a>
             <br/>
         </p>
 

--- a/pydis_site/templates/events/pages/code-jams/8/_index.html
+++ b/pydis_site/templates/events/pages/code-jams/8/_index.html
@@ -31,7 +31,7 @@
         <p>
             <a href="https://www.youtube.com/watch?v=DV3uMdsw9KE" title="Perceptive Porcupines Demo Video" target="_blank" rel="noopener"><i class="fa fa-video"> </i> Demo video</a>
             <br/>
-            <a href="https://github.com/what-the-python/wtpython" title="Perceptive Porcupines GitHub Repository" target="_blank" rel="noopener"><i class="fa fa-github"></i> GitHub Repository</a>
+            <a href="https://github.com/what-the-python/wtpython" title="Perceptive Porcupines GitHub Repository" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub Repository</a>
             <br/>
 
         </p>
@@ -46,7 +46,7 @@
         <p>
             <a href="https://www.youtube.com/watch?v=WI9tgQeAfXw" title="Lovable Lobsters Demo Video" target="_blank" rel="noopener"><i class="fa fa-video"> </i> Demo video</a>
             <br/>
-            <a href="https://github.com/A5rocks/code-jam-8" title="Lovable Lobsters GitHub Repository" target="_blank" rel="noopener"><i class="fa fa-github"></i> GitHub Repository</a>
+            <a href="https://github.com/A5rocks/code-jam-8" title="Lovable Lobsters GitHub Repository" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub Repository</a>
             <br/>
         </p>
 
@@ -58,7 +58,7 @@
             Just like a real world Rubik's cube, you can move this cube around to look at it from all sides. And, of course, you can rotate the individual discs it is made up of to first scramble up the order and then to try and solve it into perfect ordering again.
         </p>
         <p>
-            <a href="https://github.com/bjoseru/pdcj8-robust-reindeer" title="Robust Reindeer GitHub Repository" target="_blank" rel="noopener"><i class="fa fa-github"></i> GitHub Repository</a>
+            <a href="https://github.com/bjoseru/pdcj8-robust-reindeer" title="Robust Reindeer GitHub Repository" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub Repository</a>
             <br/>
         </p>
 

--- a/pydis_site/templates/events/pages/code-jams/9/_index.html
+++ b/pydis_site/templates/events/pages/code-jams/9/_index.html
@@ -29,7 +29,7 @@
             Drawn is based on old school Pictionary game, with additional surprises waiting for the drawer each turn.
         </p>
         <p>
-            <a href="https://github.com/collerek/cerebral-centaurs" title="Cerebral Centaurs GitHub Repository" target="_blank" rel="noopener"><i class="fa fa-github"></i> GitHub Repository</a>
+            <a href="https://github.com/collerek/cerebral-centaurs" title="Cerebral Centaurs GitHub Repository" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub Repository</a>
             <br/>
 
         </p>
@@ -42,7 +42,7 @@
         <p>
             <a href="https://www.youtube.com/watch?v=-VQ_ijuo-Mg" title="Kingly Kelpies Demo Video" target="_blank" rel="noopener"><i class="fa fa-video"> </i> Demo video</a>
             <br/>
-            <a href="https://github.com/Kingly-elpies/KinglyKelpies" title="Kingly Kelpies GitHub Repository" target="_blank" rel="noopener"><i class="fa fa-github"></i> GitHub Repository</a>
+            <a href="https://github.com/Kingly-elpies/KinglyKelpies" title="Kingly Kelpies GitHub Repository" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub Repository</a>
             <br/>
         </p>
 
@@ -51,7 +51,7 @@
         <p class="my-1">
             Curse of the Mites is a text based MUD (multi-user dungeon) in which you play as a caterpillar whose goal is to grow into a butterfly to escape the forest cursed by mites.
         <p>
-            <a href="https://github.com/AbooMinister25/Curse-of-the-Mites" title="Logical Leprechauns GitHub Repository" target="_blank" rel="noopener"><i class="fa fa-github"></i> GitHub Repository</a>
+            <a href="https://github.com/AbooMinister25/Curse-of-the-Mites" title="Logical Leprechauns GitHub Repository" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub Repository</a>
             <br/>
         </p>
 

--- a/pydis_site/templates/home/timeline.html
+++ b/pydis_site/templates/home/timeline.html
@@ -344,7 +344,7 @@
 
       <div class="cd-timeline__block">
         <div class="cd-timeline__img pastel-red cd-timeline__img--picture">
-          <i class="fa fa-youtube-play"></i>
+          <i class="fab fa-youtube"></i>
         </div>
 
         <div class="cd-timeline__content has-background-white-bis text-component">
@@ -473,7 +473,7 @@
 
       <div class="cd-timeline__block">
         <div class="cd-timeline__img pastel-red cd-timeline__img--picture">
-          <i class="fa fa-snowflake-o"></i>
+          <i class="fa fa-snowflake"></i>
         </div>
 
         <div class="cd-timeline__content has-background-white-bis text-component">


### PR DESCRIPTION
We were using some Font Awesome 4 classes, eg:
- https://fontawesome.com/v4/icon/snowflake-o
- https://fontawesome.com/v4/icon/github

Which have since been removed. They don't show up correctly after switching to Font Awesome 6 (in #1232).

This is because the Kit we were previously using included some JS files that handled the backwards compatibility. (Thanks to @lemonsaurus for finding this out)

This fix replaces these font awesome classes to the most sensible replacements I could find, which are the new class names and should all display correctly.

### Timeline

https://pythondiscord.com/timeline/
https://deploy-preview-1255--pydis-static.netlify.app/timeline/

1

![image](https://github.com/python-discord/site/assets/50042066/4ef5ce0b-36ab-40a6-a34e-674ef01116fd)
![image](https://github.com/python-discord/site/assets/50042066/e94701d5-ba93-4de2-8f98-d98a7f44cec0)


2

![image](https://github.com/python-discord/site/assets/50042066/7517ba13-0590-433e-8577-ddb595fedec8)
![image](https://github.com/python-discord/site/assets/50042066/568b4029-dcde-45b6-bb47-27d9ba4f15aa)

### Resources 

https://pythondiscord.com/resources/?type=project-ideas
https://deploy-preview-1255--pydis-static.netlify.app/resources/?type=project-ideas

![image](https://github.com/python-discord/site/assets/50042066/5d018f88-0c5e-445b-8c4d-22ad2f3d4245)
![image](https://github.com/python-discord/site/assets/50042066/28732b52-9c14-4f01-aad8-ccd6af650dea)

### Code Jam results

https://www.pythondiscord.com/events/code-jams/
https://deploy-preview-1255--pydis-static.netlify.app/events/code-jams/

For CJ10, 9, 8.

![image](https://github.com/python-discord/site/assets/50042066/f02de88e-0bd9-4eea-9601-0013130c551f)
![image](https://github.com/python-discord/site/assets/50042066/6a3538f4-b71c-4c5f-86ab-f75dbdc3f55b)
