### PR TITLE
Timeline: Fix Liechtenstein postcard image

### DIFF
--- a/pydis_site/templates/home/timeline.html
+++ b/pydis_site/templates/home/timeline.html
@@ -668,7 +668,7 @@
         <div class="cd-timeline__content has-background-white-bis text-component">
           <h2 class="has-text-dark">Python Discord hits 40,000 members, and is now bigger than Liechtenstein.</h2>
           <p class="color-contrast-medium has-text-dark"><img
-              src="https://cdn.discordapp.com/attachments/354619224620138496/699666518476324954/unknown.png">
+              src="https://raw.githubusercontent.com/python-discord/branding/main/wallpapers/bigger%20than%20liechtenstein/pydis%20postcard.png">
           </p>
 
           <div class="flex justify-between items-center">


### PR DESCRIPTION
The discord link which we've previously used stopped working for me, I've switched it to the raw github link from our branding repo instead.