### PR TITLE
Removed inactive users from `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,16 +2,7 @@
 pydis_site/apps/api/models/bot/infraction.py    @MarkKoz
 pydis_site/apps/api/viewsets/bot/infraction.py  @MarkKoz
 
-# Home app
-pydis_site/apps/home/**                         @ks129
-
-# Django ORM
-**/models/**                                    @Den4200
-
 # CI & Docker
-.github/workflows/**                            @MarkKoz @ks129
+.github/workflows/**                            @MarkKoz
 Dockerfile                                      @MarkKoz
 docker-compose.yml                              @MarkKoz
-
-# Metricity
-pydis_site/apps/api/models/bot/metricity.py     @jb3


### PR DESCRIPTION
Updated [CODEOWNERS](https://github.com/python-discord/site/blob/main/.github/CODEOWNERS) via removing users that are no longer active on this repo.