### PR TITLE
Fix navbar dropdown toggle for touchscreens using Safari

### DIFF
--- a/pydis_site/templates/base/base.html
+++ b/pydis_site/templates/base/base.html
@@ -32,7 +32,9 @@
   {% block head %}{% endblock %}
 
 </head>
-<body class="site">
+<!-- The tabindex attribute fixes the inability to toggle the navbar dropdown
+  -- on touchscreens using Safari. -->
+<body class="site" tabindex="-1">
   <!-- Git hash for this release: {{ git_sha }} -->
 
 <main class="site-content">


### PR DESCRIPTION
Fixes #1208.

All the discussion/details regarding implementation can be found in the linked issue.

It'd be best if you have a target device to test it on, but if not, take a look at [this stackoverflow answer](https://stackoverflow.com/a/58767695).