### PR TITLE
Don't propagate the status received from Discord to GitHub Webhook

### DIFF
--- a/pydis_site/apps/api/tests/test_github_webhook_filter.py
+++ b/pydis_site/apps/api/tests/test_github_webhook_filter.py
@@ -44,8 +44,10 @@ class GitHubWebhookFilterAPITests(APITestCase):
             context_mock.read.return_value = b'{"status": "ok"}'
 
             response = self.client.post(url, data=payload, headers=headers)
-            self.assertEqual(response.status_code, context_mock.status)
-            self.assertEqual(response.headers.get('X-Clacks-Overhead'), 'Joe Armstrong')
+            response_body = response.json()
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response_body.get("headers", {}).get("X-Clacks-Overhead"), 'Joe Armstrong')
+            self.assertEqual(response_body.get("original_status"), 299)
 
     def test_rate_limit_is_logged_to_sentry(self):
         url = reverse('api:github-webhook-filter', args=('id', 'token'))

--- a/pydis_site/apps/api/tests/test_github_webhook_filter.py
+++ b/pydis_site/apps/api/tests/test_github_webhook_filter.py
@@ -62,3 +62,17 @@ class GitHubWebhookFilterAPITests(APITestCase):
             self.client.post(url, data=payload, headers=headers)
 
             logger.warning.assert_called_once()
+
+    def test_other_error_is_logged(self):
+        url = reverse('api:github-webhook-filter', args=('id', 'token'))
+        payload = {}
+        headers = {'X-GitHub-Event': 'pull_request_review'}
+        with (
+            mock.patch('urllib.request.urlopen') as urlopen,
+            mock.patch.object(GitHubWebhookFilterView, "logger") as logger,
+        ):
+            urlopen.side_effect = HTTPError(None, 451, 'Unavailable For Legal Reasons', {}, None)
+            logger.warning = mock.PropertyMock()
+            self.client.post(url, data=payload, headers=headers)
+
+            logger.warning.assert_called_once()

--- a/pydis_site/apps/api/views.py
+++ b/pydis_site/apps/api/views.py
@@ -305,7 +305,14 @@ class GitHubWebhookFilterView(APIView):
         )
         headers.pop('Connection', None)
         headers.pop('Content-Length', None)
-        return Response(data=body, headers=headers, status=response_status)
+
+        response_body = {
+            "original_status": response_status,
+            "data": body.decode("utf-8"),
+            "headers": headers,
+        }
+
+        return Response(response_body)
 
     def send_webhook(
         self,

--- a/pydis_site/apps/api/views.py
+++ b/pydis_site/apps/api/views.py
@@ -304,9 +304,21 @@ class GitHubWebhookFilterView(APIView):
             webhook_id, webhook_token, request.data, dict(request.headers),
         )
 
+        body_decoded = body.decode("utf-8")
+
+        if (
+            not (status.HTTP_200_OK <= response_status < status.HTTP_300_MULTIPLE_CHOICES)
+            and response_status != status.HTTP_429_TOO_MANY_REQUESTS
+        ):
+            self.logger.warning(
+                "Failed to send GitHub webhook to Discord. Response code %d, body: %s",
+                response_status,
+                body_decoded,
+            )
+
         response_body = {
             "original_status": response_status,
-            "data": body.decode("utf-8"),
+            "data": body_decoded,
             "headers": headers,
         }
 

--- a/pydis_site/apps/api/views.py
+++ b/pydis_site/apps/api/views.py
@@ -303,8 +303,6 @@ class GitHubWebhookFilterView(APIView):
         (response_status, headers, body) = self.send_webhook(
             webhook_id, webhook_token, request.data, dict(request.headers),
         )
-        headers.pop('Connection', None)
-        headers.pop('Content-Length', None)
 
         response_body = {
             "original_status": response_status,


### PR DESCRIPTION
When we received a bad request exception from Discord (which is not actually representative of an error here), we were propagating this back to GitHub.

Instead, we should always return a success request if we have been successful in the proxy attempt, and return the downstream status code as a part of the response body.

This prevents GitHub Webhook Bad Requests being logged to site logs.