### PR TITLE
Prefetch the filter_list field in the FilterListSerializer

### DIFF
--- a/pydis_site/apps/api/serializers.py
+++ b/pydis_site/apps/api/serializers.py
@@ -434,7 +434,7 @@ class FilterListSerializer(ModelSerializer):
         schema = {name: getattr(instance, name) for name in BASE_FILTERLIST_FIELDS}
         schema['filters'] = [
             FilterSerializer(many=False).to_representation(instance=item)
-            for item in Filter.objects.filter(filter_list=instance.id)
+            for item in Filter.objects.filter(filter_list=instance.id).prefetch_related('filter_list')
         ]
 
         settings = {name: getattr(instance, name) for name in BASE_SETTINGS_FIELDS}


### PR DESCRIPTION
We were experiencing an issue in production where the `api:bot:filterlist-list` view was taking several seconds to process, upon enabling query logs and monitoring for this we found it was making a query for every filter in the database.

Prefetching the `filter_list` field solves this and greatly reduces the query count, optimising the route.