### PR TITLE
Replace `docker-compose` with `docker compose` in action

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -18,8 +18,8 @@ jobs:
 
       # Start the database early to give it a chance to get ready before
       # we start running tests.
-      - name: Run database using docker-compose
-        run: docker-compose run -d -p 7777:5432 --name pydis_web postgres
+      - name: Run database using docker compose
+        run: docker compose run -d -p 7777:5432 --name pydis_web postgres
 
       # We will not run `flake8` here, as we will use a separate flake8
       # action.
@@ -50,8 +50,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: ./coverage.lcov
 
-      - name: Tear down docker-compose containers
-        run: docker-compose stop
+      - name: Tear down docker compose containers
+        run: docker compose stop
         if: ${{ always() }}
 
       # Prepare the Pull Request Payload artifact. If this fails, we


### PR DESCRIPTION
Assuming it's just a drop in change

Done because our [lint workflow is failing](https://github.com/python-discord/site/actions/runs/8527879039/job/23360258497) since `docker-compose` was removed from the image we're using https://github.com/actions/runner-images/issues/9557