### PR TITLE
Use Prometheus drop-in database engines

### DIFF
--- a/pydis_site/settings.py
+++ b/pydis_site/settings.py
@@ -188,8 +188,8 @@ WSGI_APPLICATION = 'pydis_site.wsgi.application'
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
 DATABASES = {
-    'default': env.db(),
-    'metricity': env.db('METRICITY_DB_URL'),
+    'default': env.db(engine="django_prometheus.db.backends.postgresql"),
+    'metricity': env.db('METRICITY_DB_URL', engine="django_prometheus.db.backends.postgresql"),
 } if not STATIC_BUILD else {}
 
 # Password validation


### PR DESCRIPTION
This is a drop-in change that allows the django-prometheus package to export
metrics detailing statistics on database usage within the application.

There are no other changes required and this is completely transparent to the
rest of the application, the engine is just a passthrough to the underneath
postgresql engine.