### PR TITLE
Update production deployment configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN if [ $STATIC_BUILD = "TRUE" ] ; \
   then SECRET_KEY=dummy_value poetry run python manage.py distill-local build --traceback --force ; \
 fi
 
-# Run web server through custom manager
-ENTRYPOINT ["poetry", "run", "python", "manage.py"]
-CMD ["run"]
+ENTRYPOINT ["poetry", "run"]
+CMD ["gunicorn", "--preload", "-b", "0.0.0.0:8000", \
+     "pydis_site.wsgi:application", "-w", "2", "--statsd-host", \
+     "graphite.default.svc.cluster.local:8125", "--statsd-prefix", "site", \
+     "--config", "file:gunicorn.conf.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: ["run", "--debug"]
+    command: ["python", "manage.py", "run"]
     networks:
       default:
         aliases:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ select = ["ANN", "B", "C4", "D", "DJ", "DTZ", "E", "F", "ISC", "INT", "N", "PGH"
 "pydis_site/apps/api/models/bot/off_topic_channel_name.py" = ["RUF001"]
 
 [tool.taskipy.tasks]
-start = "python manage.py run --debug"
+start = "python manage.py run"
 makemigrations = "python manage.py makemigrations"
 django_shell = "python manage.py shell"
 test = "coverage run manage.py test"


### PR DESCRIPTION
- Change `manage.py` to only be used for debug running of the site
- Update Dockerfile to use the `gunicorn` command to run site in production
- Update docker-compose for new local debug running

Hopefully, this will rectify some odd database issues we've been having related
to other application and database code being loaded before the first request is
hit, leading to errors on first request served by site after boot.