### PR TITLE
Use kebab-case for keys of `valid_filters` in resources

### DIFF
--- a/pydis_site/apps/resources/apps.py
+++ b/pydis_site/apps/resources/apps.py
@@ -91,7 +91,7 @@ class ResourcesConfig(AppConfig):
         # A complete list of valid filter names
         self.valid_filters = {
             "topics": [to_kebabcase(topic) for topic in self.filters["Topics"]["filters"]],
-            "payment_tiers": [
+            "payment-tiers": [
                 to_kebabcase(tier) for tier in self.filters["Payment tiers"]["filters"]
             ],
             "type": [to_kebabcase(type_) for type_ in self.filters["Type"]["filters"]],


### PR DESCRIPTION
The YAML side uses snake case, whereas the HTML template and JavaScript use kebab case. This difference affects only `Payment tiers` right now.

Currently if the page has a payment tier filter active, reloading the page would lose the filter. A simple fix would be to use kebab case in `valid_filters` which will be used in JavaScript.

Demo:
https://deploy-preview-1373--pydis-static.netlify.app/resources/?payment-tiers=free&difficulty=beginner
https://www.pythondiscord.com/resources/?payment-tiers=free&difficulty=beginner