### PR TITLE
Add Discord.py masterclass resource

### DIFF
--- a/pydis_site/apps/resources/resources/discord_py_masterclass.yaml
+++ b/pydis_site/apps/resources/resources/discord_py_masterclass.yaml
@@ -1,0 +1,12 @@
+description: A whistlestop tour of the functionality of discord.py, the most popular Python library for Discord
+name: Discord.py Masterclass
+title_url: https://fallendeity.github.io/discord.py-masterclass
+tags:
+  topics:
+    - discord bots
+  payment_tiers:
+    - free
+  difficulty:
+    - intermediate
+  type:
+    - tutorial


### PR DESCRIPTION
Adds a resource suggested in community meta.

I've scoped it out and believe that:
- It teaches good coding practices for the most part
- It makes good use of type annotations
- It covers a wide range of functionality
- It's content is appropriate and keeps in line with our community expectations