### PR TITLE
Remove discriminator from bot logs view

### DIFF
--- a/pydis_site/apps/api/models/bot/user.py
+++ b/pydis_site/apps/api/models/bot/user.py
@@ -76,7 +76,9 @@ class User(ModelReprMixin, models.Model):
 
     def __str__(self):
         """Returns the name and discriminator for the current user, for display purposes."""
-        return f"{self.name}#{self.discriminator:04d}"
+        if self.discriminator:
+            return f"{self.name}#{self.discriminator:04d}"
+        return self.name
 
     @property
     def top_role(self) -> Role:

--- a/pydis_site/apps/api/tests/test_models.py
+++ b/pydis_site/apps/api/tests/test_models.py
@@ -187,3 +187,9 @@ class StringDunderMethodTests(SimpleTestCase):
             "Nomination of Hemlock's Cat#7777 (active)",
             str(self.nomination)
         )
+
+
+class UserTests(SimpleTestCase):
+    def test_str_without_discriminator(self) -> None:
+        user = User(name="lemonfannumber1")
+        self.assertEqual(str(user), "lemonfannumber1")


### PR DESCRIPTION
When a user does not have a discriminator, do not display it anymore.
Behaviour for users with discriminators (for historic infractions is
unchanged).
