### PR TITLE
docs: update required privileged intents in bot.md

### DIFF
--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot.md
@@ -57,11 +57,11 @@ See [here](../creating-bot-account) for help with setting up a bot account. Once
 #### Privileged Intents
 
 It is necessary to explicitly request that your Discord bot receives certain gateway events.
-The Python bot requires the `Server Member Intent` to function.
+The Python bot requires `Server Member Intent` and `Message Content Intent` to function.
 In order to enable it, visit the [Developer Portal](https://discord.com/developers/applications/) (from where you copied your bot's login token) and scroll down to the `Privileged Gateway Intents` section.
 The `Presence Intent` is not necessary and can be left disabled.
 
-If your bot fails to start with a `PrivilegedIntentsRequired` exception, this indicates that the required intent was not enabled.
+If your bot fails to start with a `PrivilegedIntentsRequired` exception, this indicates that the required intents were not enabled.
 
 ---
 

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/setting-test-server-and-bot-account.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/setting-test-server-and-bot-account.md
@@ -18,8 +18,11 @@ icon: fab fa-discord
 4. Change your bot's `Public Bot` setting off so only you can invite it, save, and then get your **Bot Token** with the `Copy` button.
 > **Note:** **DO NOT** post your bot token anywhere public, or it can and will be compromised.
 5. Save your **Bot Token** somewhere safe to use in the project settings later.
-6. In the `OAuth2` tab, grab the **Client ID**.
-7. Replace `<CLIENT_ID_HERE>` in the following URL and visit it in the browser to invite your bot to your new test server.
+6. Scroll down to the `Privileged Gateway Intents` section and enable required intents.
+> For Sir Lancebot, you need to enable `Server Member Intent`. For Python Bot, you need to enable `Server Member Intent` and `Message Content Intent`.
+> Failure to do so will result in a `PrivilegedIntentsRequired` exception when you start the bot.
+7. In the `OAuth2` tab, grab the **Client ID**.
+8. Replace `<CLIENT_ID_HERE>` in the following URL and visit it in the browser to invite your bot to your new test server.
 ```plaintext
 https://discordapp.com/api/oauth2/authorize?client_id=<CLIENT_ID_HERE>&permissions=8&scope=bot
 ```


### PR DESCRIPTION
I was trying to setup the bot, and I kept getting the `PrivilegedIntentsRequired` error.

Turns out when setting `Privileged Gateway Intents`, you also need to enable `Message Content Intent`, which is a relatively new intent introduced by Discord.

This PR updates the documentation to include that.