### PR TITLE
Clarify embed characters limit

### DIFF
--- a/pydis_site/apps/content/resources/guides/python-guides/discord-embed-limits.md
+++ b/pydis_site/apps/content/resources/guides/python-guides/discord-embed-limits.md
@@ -11,11 +11,11 @@ If you plan on using embed responses for your bot you should know the limits of 
 - A **field name/title** is limited to **256 character** and the **value of the field** is limited to **1024 characters**
 - Embed **footer** is limited to **2048 characters**
 - Embed **author name** is limited to **256 characters**
-- The **total of characters** allowed in an embed is **6000**
+- The **total characters** of all embeds in a single message is limited to **6000**
+- A message is limited to **10 embeds**
 
 Now if you need to get over this limit (for example for a help command), you would need to use pagination.
 There are several ways to do that:
 
-- A library called **[disputils](https://pypi.org/project/disputils)**
 - An experimental library made by the discord.py developer called **[discord-ext-menus](https://github.com/Rapptz/discord-ext-menus)**
 - Make your own setup using **[wait_for()](https://discordpy.readthedocs.io/en/stable/ext/commands/api.html#discord.ext.commands.Bot.wait_for)** and wait for a reaction to be added


### PR DESCRIPTION
The guide didn't mention how many embeds are allowed per message nor that the total characters is shared across all embeds of the message.

Also removed the `disputils` library from pagination options as it's not supported for discord.py 2.x -> https://github.com/LiBa001/disputils/blob/master/setup.py#L21