### PR TITLE
Add the LinkedIn Group: Python Developers Community as a resource

### DIFF
--- a/pydis_site/apps/resources/resources/Python_Developers_Community.yaml
+++ b/pydis_site/apps/resources/resources/Python_Developers_Community.yaml
@@ -1,0 +1,13 @@
+description: A LinkedIn group for both experienced developers and people that want to start learning and using the Python programming language. Discover best practices, tips & tricks, share learning resources  and other technical content, showcase your projects & repo's and ask questions or feedback.
+name: Python Developers Community (moderated) on LinkedIn
+title_url: https://www.linkedin.com/groups/25827/
+tags:
+  topics:
+    - general
+  payment_tiers:
+    - free
+  difficulty:
+    - beginner
+    - intermediate
+  type:
+    - community


### PR DESCRIPTION
Adds the LinkedIn Group: Python Developers Community (moderated) to the resource page.

The group is moderated and requires users in their space to follow the PSF Code of conduct, which aligns with our own. 


