### PR TITLE
Do not require "active" to be sent in PATCH infraction

### DIFF
--- a/pydis_site/apps/api/tests/test_infractions.py
+++ b/pydis_site/apps/api/tests/test_infractions.py
@@ -329,7 +329,7 @@ class InfractionTests(AuthenticatedAPITestCase):
 
     def test_partial_update_returns_400_for_frozen_field(self):
         url = reverse('api:bot:infraction-detail', args=(self.ban_hidden.id,))
-        data = {'user': 6, 'active': True}
+        data = {'user': 6}
 
         response = self.client.patch(url, data=data)
         self.assertEqual(response.status_code, 400)

--- a/pydis_site/apps/api/viewsets/bot/infraction.py
+++ b/pydis_site/apps/api/viewsets/bot/infraction.py
@@ -161,6 +161,7 @@ class InfractionViewSet(
     def partial_update(self, request: HttpRequest, *_args, **_kwargs) -> Response:
         """Method that handles the nuts and bolts of updating an Infraction."""
         instance = self.get_object()
+        request.data.setdefault("active", True)
         serializer = self.get_serializer(instance, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()


### PR DESCRIPTION
Regression from the DRF update.
