### PR TITLE
Update Timeline (400k members, #coveragepy, 3.13 release stream)

### DIFF
--- a/pydis_site/apps/timeline/entries/2024-06-20_partnership-with-coveragepy.md
+++ b/pydis_site/apps/timeline/entries/2024-06-20_partnership-with-coveragepy.md
@@ -1,0 +1,8 @@
+---
+title: Partnership with Coverage.py
+date: June 20th, 2024
+icon: fa fa-handshake
+
+---
+
+The `#coveragepy` channel is created for discussion of Coverage.py, the popular code coverage measurement tool.

--- a/pydis_site/apps/timeline/entries/2024-10-07_python-313-release-stream.md
+++ b/pydis_site/apps/timeline/entries/2024-10-07_python-313-release-stream.md
@@ -1,0 +1,16 @@
+---
+title: Python 3.13 Release Stream
+date: Oct 10th, 2022
+icon: pydis
+---
+
+Another year, another Python release stream! Hosted by KeithTheEE, and CPython
+Core Team members Łukasz Langa, Pablo Galindo Salgado, and Brandt Bucher.
+Together, they discuss the new features of the release, and what goes into
+contributing to Python.
+
+<div class="force-aspect-container">
+<iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+allowfullscreen="" class="force-aspect-content" frameborder="0"
+src="https://www.youtube.com/embed/7MAPzvv3ZG0"></iframe>
+</div>

--- a/pydis_site/apps/timeline/entries/2025-04-10_400000-members.md
+++ b/pydis_site/apps/timeline/entries/2025-04-10_400000-members.md
@@ -1,0 +1,8 @@
+---
+title: We hit 400 000 members!
+date: April 10th, 2025
+icon: fa fa-users
+icon_color: pastel-dark-blue
+---
+
+We're growing slower, but we're still growing! Python Discord's now has 400,000 members.


### PR DESCRIPTION
It's been a while since the last update of the timeline, I've added three more items:

- The 3.13 release stream
- Adding the `#coveragepy` channel
- Hitting the 400,000 member mark