### PR TITLE
Address some issues from the accessibility milestone

### DIFF
--- a/pydis_site/apps/timeline/entries/2018-02-03_our-logo-is-born.md
+++ b/pydis_site/apps/timeline/entries/2018-02-03_our-logo-is-born.md
@@ -5,5 +5,5 @@ icon: pydis
 ---
 
 <p style="background-color: #7289DA; border-radius: 10px;">
-  <img style="padding-right: 20px;" src="https://raw.githubusercontent.com/python-discord/branding/main/logos/logo_banner/logo_site_banner.svg">
+  <img style="padding-right: 20px;" src="https://raw.githubusercontent.com/python-discord/branding/main/logos/logo_banner/logo_site_banner.svg" alt="Python Discord Logo">
 </p>

--- a/pydis_site/apps/timeline/entries/2024-10-07_python-313-release-stream.md
+++ b/pydis_site/apps/timeline/entries/2024-10-07_python-313-release-stream.md
@@ -1,6 +1,6 @@
 ---
 title: Python 3.13 Release Stream
-date: Oct 10th, 2022
+date: Oct 10th, 2024
 icon: pydis
 ---
 

--- a/pydis_site/templates/events/main_events.html
+++ b/pydis_site/templates/events/main_events.html
@@ -38,7 +38,7 @@
     </div>
     <div class="card">
         <div class="card-image">
-            <img loading=lazy src="/static/images/events/gallery/adventofcode.png" alt="Server icon for AoC">
+            <img loading=lazy src="/static/images/events/gallery/adventofcode.png" alt="Server icon for Advent of Code">
         </div>
         <div class="card-content">
             <h2 class="title is-4"><a href="{% url "events:page" path="adventofcode" %}">Advent of code</a></h2>
@@ -53,7 +53,7 @@
     </div>
     <div class="card">
         <div class="card-image">
-            <img loading=lazy src="/static/images/events/gallery/adventofcode.png" alt="Server icon for AoC">
+            <img loading=lazy src="/static/images/events/gallery/adventofcode.png" alt="Server icon for Advent of Code">
         </div>
         <div class="card-content">
             <h2 class="title is-4"><a href="{% url "events:page" path="revivalofcode" %}">Revival of Code</a></h2>

--- a/pydis_site/templates/events/other_events.html
+++ b/pydis_site/templates/events/other_events.html
@@ -35,7 +35,7 @@
         <article class="media">
             <div class="media-left">
                 <p class="image">
-                    <img loading=lazy class="is-rounded" src="https://s3.dualstack.us-east-2.amazonaws.com/pythondotorg-assets/media/files/python-logo-only.svg" style="width: 3rem;">
+                    <img loading=lazy class="is-rounded" src="https://s3.dualstack.us-east-2.amazonaws.com/pythondotorg-assets/media/files/python-logo-only.svg" style="width: 3rem;" alt="">
                 </p>
             </div>
             <div class="media-content">
@@ -85,7 +85,7 @@
         <article class="media">
             <div class="media-left">
                 <p class="image">
-                    <img loading=lazy class="is-rounded" src="https://s3.dualstack.us-east-2.amazonaws.com/pythondotorg-assets/media/files/python-logo-only.svg" style="width: 3rem;">
+                    <img loading=lazy class="is-rounded" src="https://s3.dualstack.us-east-2.amazonaws.com/pythondotorg-assets/media/files/python-logo-only.svg" style="width: 3rem;" alt="">
                 </p>
             </div>
             <div class="media-content">
@@ -111,7 +111,7 @@
         <article class="media">
             <div class="media-left">
                 <p class="image">
-                    <img loading=lazy src="/static/images/events/pixels_logo_transparent.gif" style="width: 3rem;">
+                    <img loading=lazy src="/static/images/events/pixels_logo_transparent.gif" style="width: 3rem;" alt="">
                 </p>
             </div>
             <div class="media-content">

--- a/pydis_site/templates/events/scheduled_events.html
+++ b/pydis_site/templates/events/scheduled_events.html
@@ -3,7 +3,7 @@
     <article class="media">
         <div class="media-left">
             <p class="image is-64x64">
-                <a href="{% url "events:page" path="code-jams/12" %}"><img class="is-rounded" src="/static/images/events/summer_code_jam_2025/logo.png" alt=""></a>
+                <a href="{% url "events:page" path="code-jams/12" %}"><img class="is-rounded" src="/static/images/events/summer_code_jam_2025/logo.png" alt="Summer Code Jam 2025"></a>
             </p>
         </div>
         <div class="media-content">
@@ -26,7 +26,7 @@
     <article class="media">
         <div class="media-left">
             <p class="image is-64x64">
-                <a href="{% url "events:page" path="pyweek" %}"><img class="is-rounded" src="/static/images/events/icons/pyweek.png" alt=""></a>
+                <a href="{% url "events:page" path="pyweek" %}"><img class="is-rounded" src="/static/images/events/icons/pyweek.png" alt="PyWeek 38"></a>
             </p>
         </div>
         <div class="media-content">
@@ -49,7 +49,7 @@
     <article class="media">
         <div class="media-left">
             <p class="image is-64x64">
-                <a href="{% url "events:page" path="adventofcode" %}"><img class="is-rounded" src="/static/images/events/icons/adventofcode.png" alt=""></a>
+                <a href="{% url "events:page" path="adventofcode" %}"><img class="is-rounded" src="/static/images/events/icons/adventofcode.png" alt="Advent of Code"></a>
             </p>
         </div>
         <div class="media-content">

--- a/pydis_site/templates/events/scheduled_events.html
+++ b/pydis_site/templates/events/scheduled_events.html
@@ -3,7 +3,7 @@
     <article class="media">
         <div class="media-left">
             <p class="image is-64x64">
-                <a href="{% url "events:page" path="code-jams/12" %}"><img class="is-rounded" src="/static/images/events/summer_code_jam_2025/logo.png"></a>
+                <a href="{% url "events:page" path="code-jams/12" %}"><img class="is-rounded" src="/static/images/events/summer_code_jam_2025/logo.png" alt=""></a>
             </p>
         </div>
         <div class="media-content">
@@ -26,7 +26,7 @@
     <article class="media">
         <div class="media-left">
             <p class="image is-64x64">
-                <a href="{% url "events:page" path="pyweek" %}"><img class="is-rounded" src="/static/images/events/icons/pyweek.png"></a>
+                <a href="{% url "events:page" path="pyweek" %}"><img class="is-rounded" src="/static/images/events/icons/pyweek.png" alt=""></a>
             </p>
         </div>
         <div class="media-content">
@@ -49,7 +49,7 @@
     <article class="media">
         <div class="media-left">
             <p class="image is-64x64">
-                <a href="{% url "events:page" path="adventofcode" %}"><img class="is-rounded" src="/static/images/events/icons/adventofcode.png"></a>
+                <a href="{% url "events:page" path="adventofcode" %}"><img class="is-rounded" src="/static/images/events/icons/adventofcode.png" alt=""></a>
             </p>
         </div>
         <div class="media-content">

--- a/pydis_site/templates/events/sidebar/adventofcode/useful-links.html
+++ b/pydis_site/templates/events/sidebar/adventofcode/useful-links.html
@@ -1,6 +1,6 @@
 <div class="box">
     <div class="has-text-centered">
-        <img src="https://raw.githubusercontent.com/python-discord/branding/main/events/christmas/server_icons/festive_256.gif" style="border-radius: 10px;" alt="Server icon for AoC">
+        <img src="https://raw.githubusercontent.com/python-discord/branding/main/events/christmas/server_icons/festive_256.gif" style="border-radius: 10px;" alt="Server icon for Advent of Code">
     </div>
     <p class="menu-label">Quick links</p>
     <ul class="menu-list">

--- a/pydis_site/templates/events/sidebar/main_sidebar.html
+++ b/pydis_site/templates/events/sidebar/main_sidebar.html
@@ -3,7 +3,7 @@
     <article class="media">
         <div class="media-left">
             <p class="image is-32x32">
-                <img class="is-rounded" src="/static/images/events/summer_code_jam_2023/logo.PNG">
+                <img class="is-rounded" src="/static/images/events/summer_code_jam_2023/logo.PNG" alt="">
             </p>
         </div>
         <div class="media-content">
@@ -16,7 +16,7 @@
     <article class="media">
         <div class="media-left">
             <p class="image is-32x32">
-                <img class="is-rounded" src="/static/images/events/icons/pyweek.png">
+                <img class="is-rounded" src="/static/images/events/icons/pyweek.png" alt="">
             </p>
         </div>
         <div class="media-content">
@@ -29,7 +29,7 @@
     <article class="media">
         <div class="media-left">
             <p class="image is-32x32">
-                <img class="is-rounded" src="/static/images/events/icons/adventofcode.png">
+                <img class="is-rounded" src="/static/images/events/icons/adventofcode.png" alt="">
             </p>
         </div>
         <div class="media-content">
@@ -42,7 +42,7 @@
     <article class="media">
         <div class="media-left">
             <p class="image is-32x32">
-                <img class="is-rounded" src="/static/images/events/icons/pyweek.png">
+                <img class="is-rounded" src="/static/images/events/icons/pyweek.png" alt="">
             </p>
         </div>
         <div class="media-content">

--- a/pydis_site/templates/events/sidebar/revivalofcode.html
+++ b/pydis_site/templates/events/sidebar/revivalofcode.html
@@ -1,6 +1,6 @@
 <div class="box">
     <div class="has-text-centered">
-        <img src="https://raw.githubusercontent.com/python-discord/branding/main/events/christmas/server_icons/festive_256.gif" style="border-radius: 10px;" alt="Server icon for AoC">
+        <img src="https://raw.githubusercontent.com/python-discord/branding/main/events/christmas/server_icons/festive_256.gif" style="border-radius: 10px;" alt="Server icon for Advent of Code">
     </div>
     <p class="menu-label">Quick links</p>
     <ul class="menu-list">

--- a/pydis_site/templates/home/index.html
+++ b/pydis_site/templates/home/index.html
@@ -36,7 +36,7 @@
                 span{height:1.5em;text-align:center;font:68px/1.5 sans-serif;color:#FFFFFFEE;text-shadow:0 0 0.1em #00000020}
               </style>
               <a href=https://www.youtube.com/embed/ZH26PuX3re0?autoplay=1>
-                <img src='{% static "images/frontpage/welcome.jpg" %}' alt='Welcome to Python Discord'>
+                <img src='{% static "images/frontpage/welcome.jpg" %}' alt='Welcome to Python Discord, click to play'>
                 <span>▶</span>
               </a>"
               allow="autoplay; accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"

--- a/pydis_site/templates/timeline/timeline.html
+++ b/pydis_site/templates/timeline/timeline.html
@@ -17,7 +17,7 @@
         <div class="timeline-icon-date">
           <div class="timeline-icon {{ entry.icon_color }}">
             {% if entry.icon == "pydis" %}
-              <img class="pydis" src="{% static "images/timeline/cd-icon-pydis.svg" %}" alt="Logo">
+              <img class="pydis" src="{% static "images/timeline/cd-icon-pydis.svg" %}" alt="">
             {% else %}
               <span class="icon"><i class="{{ entry.icon }}"></i></span>
             {% endif %}


### PR DESCRIPTION
Change log:
- Added alt-text for the Welcome Video in the homepage
- Added alt-texts of "" for images that does not affect people with screen-reader in the events page as well as the timeline page
- Changes alt-texts in the events page form "AoC" to "Advent of Code" so, people who don't have knowledge about it can still know what it is.
- Change date in the 3.13 release from `2022` to `2024`

Fixes
- #1382
- #1381
- #1406
