### PR TITLE
fix: update bot's required version and contrib deadlinks

### DIFF
--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot-extended-configuration-options.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot-extended-configuration-options.md
@@ -8,7 +8,7 @@ toc: 3
 ## Manual constants configuration
 
 Reading this means that you're ready for a bit of manual labour.
-If for some reason you've missed the automatic server setup section, you can read about it in the bot contributing guide [here](../bot.md#envserver)
+If for some reason you've missed the automatic server setup section, you can read about it in the [bot contributing guide](../bot.md#envserver).
 
 To configure the bot manually, you will **only** need to set inside the `.env.server` file the values for the channels, roles, categories, etc.
 that are used by the component you are developing.

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot-extended-configuration-options.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot-extended-configuration-options.md
@@ -105,7 +105,7 @@ Note that if you changed code that is not associated with a particular extension
 
 ## Adding new statistics
 
-Details on how to add new statistics can be found on the [statistic infrastructure page](https://blog.pythondiscord.com/statistics-infrastructure).
+Details on how to add new statistics can be found on the [statistic infrastructure page](https://blog.pythondiscord.com/post/statistics-infrastructure-at-python-discord/).
 We are always open to more statistics so add as many as you can!
 
 ---

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot.md
@@ -15,7 +15,7 @@ This page will focus on the quickest steps one can take, with mentions of altern
 ### Setup Project Dependencies
 Below are the dependencies you **must** have installed to get started with the bot.
 
-1. Make sure you have [Python 3.13](https://www.python.org/downloads/) installed. It helps if it is your system's default Python version.
+1. Make sure you have [Python 3.13](https://www.python.org/downloads/) installed. uv [can also be used to](https://docs.astral.sh/uv/guides/install-python/#installing-python) install Python, if desired.
 2. [Install uv](https://github.com/astral-sh/uv#installation).
 3. [Install the project's dependencies](../installing-project-dependencies).
 4. Docker.

--- a/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot.md
+++ b/pydis_site/apps/content/resources/guides/pydis-guides/contributing/bot.md
@@ -15,7 +15,7 @@ This page will focus on the quickest steps one can take, with mentions of altern
 ### Setup Project Dependencies
 Below are the dependencies you **must** have installed to get started with the bot.
 
-1. Make sure you have [Python 3.12](https://www.python.org/downloads/) installed. It helps if it is your system's default Python version.
+1. Make sure you have [Python 3.13](https://www.python.org/downloads/) installed. It helps if it is your system's default Python version.
 2. [Install uv](https://github.com/astral-sh/uv#installation).
 3. [Install the project's dependencies](../installing-project-dependencies).
 4. Docker.


### PR DESCRIPTION
Planned to merge these with a larger update to the contributing documentation, but wanted to get these out of the way so they don't get held up by my time constraints.