### PR TITLE
Updated title URL for Two Scoops of Django

### DIFF
--- a/pydis_site/apps/resources/resources/two_scoops_of_django.yaml
+++ b/pydis_site/apps/resources/resources/two_scoops_of_django.yaml
@@ -1,7 +1,7 @@
 description: Tips, tricks, and best practices for your Django project.
   A highly recommended resource for Django web developers.
 name: Two Scoops of Django
-title_url: https://www.feldroy.com/books/two-scoops-of-django-3-x
+title_url: https://www.feldroy.com/two-scoops-of-django
 urls:
 - icon: branding/goodreads
   url: https://www.goodreads.com/book/show/55822151-two-scoops-of-django-3-x


### PR DESCRIPTION
As  [issue #1575](https://github.com/issues/created?issue=python-discord%7Csite%7C1575)  points out, the link to the book is broken, caused by the contents being moved to a different page.

I've updated the link within the .yaml pertaining to the file, no other changes were necessary.