### PR TITLE
Fix tags fetch for read-only filesystems

### DIFF
--- a/pydis_site/apps/content/tests/test_utils.py
+++ b/pydis_site/apps/content/tests/test_utils.py
@@ -1,8 +1,8 @@
 import datetime
 import json
 import tarfile
-import tempfile
 import textwrap
+from io import BytesIO
 from pathlib import Path
 from unittest import mock
 
@@ -171,26 +171,20 @@ class TagUtilsTests(TestCase):
             "This is a grouped tag!",
         )
 
-        # Generate a tar archive with a few tags
-        with tempfile.TemporaryDirectory() as tar_folder:
-            tar_folder = Path(tar_folder)
-            with tempfile.TemporaryDirectory() as folder:
-                folder = Path(folder)
-                (folder / "ignored_file.md").write_text("This is an ignored file.")
-                tags_folder = folder / "bot/resources/tags"
-                tags_folder.mkdir(parents=True)
-
-                (tags_folder / "first_tag.md").write_text(bodies[0])
-                (tags_folder / "second_tag.md").write_text(bodies[1])
-
-                group_folder = tags_folder / "some_group"
-                group_folder.mkdir()
-                (group_folder / "grouped_tag.md").write_text(bodies[2])
-
-                with tarfile.open(tar_folder / "temp.tar", "w") as file:
-                    file.add(folder, recursive=True)
-
-                body = (tar_folder / "temp.tar").read_bytes()
+        # Generate a tar archive in memory
+        tar_buffer = BytesIO()
+        with tarfile.open(fileobj=tar_buffer, mode="w") as tar:
+            for path, content in [
+                ("ignored/ignored_file.md", "This is an ignored file."),
+                ("bot/resources/tags/first_tag.md", bodies[0]),
+                ("bot/resources/tags/second_tag.md", bodies[1]),
+                ("bot/resources/tags/some_group/grouped_tag.md", bodies[2]),
+            ]:
+                data = content.encode("utf-8")
+                info = tarfile.TarInfo(name=path)
+                info.size = len(data)
+                tar.addfile(info, BytesIO(data))
+        body = tar_buffer.getvalue()
 
         returns.append(httpx.Response(
             status_code=200,
@@ -207,7 +201,7 @@ class TagUtilsTests(TestCase):
         self.assertEqual(sorted([
             models.Tag(name="first_tag", body=bodies[0], sha="123"),
             models.Tag(name="second_tag", body=bodies[1], sha="245"),
-            models.Tag(name="grouped_tag", body=bodies[2], group=group_folder.name, sha="789123"),
+            models.Tag(name="grouped_tag", body=bodies[2], group="some_group", sha="789123"),
         ], key=sort), sorted(result, key=sort))
 
     def test_get_real_tag(self):

--- a/pydis_site/apps/content/tests/test_utils.py
+++ b/pydis_site/apps/content/tests/test_utils.py
@@ -172,13 +172,14 @@ class TagUtilsTests(TestCase):
         )
 
         # Generate a tar archive in memory
+        # GitHub tarballs have a repo-prefix directory, e.g. python-discord-bot-abc123/
         tar_buffer = BytesIO()
         with tarfile.open(fileobj=tar_buffer, mode="w") as tar:
             for path, content in [
-                ("ignored/ignored_file.md", "This is an ignored file."),
-                ("bot/resources/tags/first_tag.md", bodies[0]),
-                ("bot/resources/tags/second_tag.md", bodies[1]),
-                ("bot/resources/tags/some_group/grouped_tag.md", bodies[2]),
+                ("python-discord-bot-abc123/ignored/ignored_file.md", "This is an ignored file."),
+                ("python-discord-bot-abc123/bot/resources/tags/first_tag.md", bodies[0]),
+                ("python-discord-bot-abc123/bot/resources/tags/second_tag.md", bodies[1]),
+                ("python-discord-bot-abc123/bot/resources/tags/some_group/grouped_tag.md", bodies[2]),
             ]:
                 data = content.encode("utf-8")
                 info = tarfile.TarInfo(name=path)

--- a/pydis_site/apps/content/utils.py
+++ b/pydis_site/apps/content/utils.py
@@ -3,7 +3,6 @@ import functools
 import json
 import logging
 import tarfile
-import tempfile
 from http import HTTPStatus
 from io import BytesIO
 from pathlib import Path
@@ -88,9 +87,9 @@ def fetch_tags() -> list[Tag]:
         for entry in metadata.json():
             if entry["type"] == "dir":
                 # Tag group
-                files = client.get(entry["url"])
-                files.raise_for_status()
-                files = files.json()
+                dir_response = client.get(entry["url"])
+                dir_response.raise_for_status()
+                files = dir_response.json()
             else:
                 files = [entry]
 
@@ -102,26 +101,27 @@ def fetch_tags() -> list[Tag]:
         tar_file.raise_for_status()
 
     tags = []
-    with tempfile.TemporaryDirectory() as folder:
-        with tarfile.open(fileobj=BytesIO(tar_file.content)) as repo:
-            included = []
-            for file in repo.getmembers():
-                if "/bot/resources/tags" in file.path:
-                    included.append(file)
-            repo.extractall(folder, included, filter="tar")
+    with tarfile.open(fileobj=BytesIO(tar_file.content)) as repo:
+        for file in repo.getmembers():
+            if "/bot/resources/tags" not in file.path or not file.path.endswith(".md"):
+                continue
 
-        for tag_file in Path(folder).rglob("*.md"):
-            name = tag_file.name
+            name = Path(file.path).name
+            parent = Path(file.path).parent.name
             group = None
-            if tag_file.parent.name != "tags":
+            if parent != "tags":
                 # Tags in sub-folders are considered part of a group
-                group = tag_file.parent.name
+                group = parent
 
+            f = repo.extractfile(file)
+            if f is None:
+                continue
+            body = f.read().decode("utf-8")
             tags.append(Tag(
                 name=name.removesuffix(".md"),
                 sha=hashes[name],
                 group=group,
-                body=tag_file.read_text(encoding="utf-8"),
+                body=body,
                 last_commit=None,
             ))
 


### PR DESCRIPTION
Extract tag content entirely in memory instead of writing to a temporary directory on disk. This fixes a crash in production where the app runs on a read-only filesystem.

Fixes SITE-97