### PR TITLE
Fix status embed to use single file artifact

### DIFF
--- a/.github/workflows/status-embed.yaml
+++ b/.github/workflows/status-embed.yaml
@@ -25,10 +25,9 @@ jobs:
         if: github.event.workflow_run.event == 'pull_request'
         run: |
           curl -s -H "Authorization: token $GITHUB_TOKEN" ${{ github.event.workflow_run.artifacts_url }} > artifacts.json
-          DOWNLOAD_URL=$(cat artifacts.json | jq -r '.artifacts[] | select(.name == "pull-request-payload") | .archive_download_url')
+          DOWNLOAD_URL=$(cat artifacts.json | jq -r '.artifacts[] | select(.name == "pull_request_payload.json") | .archive_download_url')
           [ -z "$DOWNLOAD_URL" ] && exit 1
-          curl -sSL -H "Authorization: token $GITHUB_TOKEN" -o pull_request_payload.zip $DOWNLOAD_URL || exit 2
-          unzip -p pull_request_payload.zip > pull_request_payload.json
+          curl -sSL -H "Authorization: token $GITHUB_TOKEN" -o pull_request_payload.json $DOWNLOAD_URL || exit 2
           [ -s pull_request_payload.json ] || exit 3
           echo "pr_author_login=$(jq -r '.user.login // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
           echo "pr_number=$(jq -r '.number // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Was broken by 7f343b28d98c0307286c63872664a747751518a1 switching to a non-zip artifact without updating the usage.