### PR TITLE
Fix n+1 warning on filters endpoint

### DIFF
--- a/pydis_site/apps/api/viewsets/bot/filters.py
+++ b/pydis_site/apps/api/viewsets/bot/filters.py
@@ -315,7 +315,7 @@ class FilterListViewSet(ModelViewSet):
     """
 
     serializer_class = FilterListSerializer
-    queryset = FilterList.objects.all()
+    queryset = FilterList.objects.prefetch_related("filters")
 
 
 class FilterViewSet(ModelViewSet):


### PR DESCRIPTION
The FilterListSerializer serializes each list's nested filters, so listing filter lists issued a separate SELECT ... FROM api_filter per list. Adding prefetch_related batches all filter rows into a single additional query