### PR TITLE
Fix n+1 on mailing list

### DIFF
--- a/pydis_site/apps/api/serializers.py
+++ b/pydis_site/apps/api/serializers.py
@@ -792,9 +792,9 @@ class OffensiveMessageSerializer(FrozenFieldsMixin, ModelSerializer):
 class MailingListSeenItemListSerializer(ListSerializer):
     """A class providing (de-)serialization of `MailingListSeenItem` instances as a list."""
 
-    def to_representation(self, objects: list[MailingListSeenItem]) -> list[str]:
+    def to_representation(self, objects: QuerySet[MailingListSeenItem]) -> list[str]:
         """Return the hashes of each seen mailing list item."""
-        return [obj['hash'] for obj in objects.values('hash')]
+        return [obj.hash for obj in objects.all()]
 
 
 class MailingListSeenItemSerializer(ModelSerializer):


### PR DESCRIPTION
.values('hash') bypassed the prefetch_related('seen_items') cache and re-hit the database once per mailing list. Using objects.all() reuses the prefetched results